### PR TITLE
Convert README to Rmd and lint files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,3 @@
+# CropWaterBalance (development version)
+
+* Initial CRAN submission.

--- a/R/CWB.R
+++ b/R/CWB.R
@@ -38,7 +38,6 @@
 #' @export
 #' @importFrom lubridate year is.Date
 #' @examples
-#' data(DataForCWB)
 #' Tavg <- DataForCWB[,2]
 #' Tmax <- DataForCWB[,3]
 #' Tmin <- DataForCWB[,4]
@@ -155,7 +154,7 @@ CWB <- function(Rain,
     }
     if (D[i, 1] > TAW[i, 1]) {D[i, 1] <- TAW[i, 1]}
     if (D[i, 1] >= (dmad[i, 1])) {
-      recom[i, 1] = paste("Yes. Irrigate", round(D[i, 1], 0), "mm")
+      recom[i, 1] <- paste("Yes. Irrigate", round(D[i, 1], 0), "mm")
     } else {
       recom[i, 1] <- c("No")
     }

--- a/R/CWB_fixedSchedule.R
+++ b/R/CWB_fixedSchedule.R
@@ -4,13 +4,15 @@
 #' It also suggests how much irrigate.
 #'
 #' @param Rain
-#' Vector, 1-column matrix or data frame with daily rainfall totals in millimetres.
+#' Vector, 1-column matrix or data frame with daily rainfall totals in
+#'  millimetres.
 #' @param ET0
-#' Vector, 1-column matrix or data frame with daily reference evapotranspiration in millimetres.
+#' Vector, 1-column matrix or data frame with daily reference evapotranspiration
+#'  in millimetres.
 #' @param AWC
-#' Vector, 1-column matrix or data frame with the available water capacity of the soil, that is:
-#' the amount of water between field capacity and permanent wilting point
-#' in millimetre of water per metres of soil.
+#' Vector, 1-column matrix or data frame with the available water capacity of
+#'  the soil, that is: the amount of water between field capacity and permanent
+#'  wilting point in millimetres of water per metres of soil.
 #' @param InitialD
 #' Single number defining in millimetre, the initial soil water deficit.
 #' It is used to start the water balance accounting.
@@ -19,133 +21,208 @@
 #' Vector, 1-column matrix or data frame defining the crop coefficient.
 #' If NULL its values are assumed to be 1.
 #' @param MAD
-#' Vector, 1-column matrix or data frame defining the management allowed depletion.
-#' Varies between 0 and 1.
+#' Vector, 1-column matrix or data frame defining the management allowed
+#'  depletion.  Varies between 0 and 1.
 #' @param Drz
 #' Vector, 1-column matrix or data frame defining the root zone depth in metres.
 #' @param Irrig
-#' Vector, 1-column matrix or data frame with net irrigation amount infiltrated into the soil
-#' for the current day in millimetres.
+#' Vector, 1-column matrix or data frame with net irrigation amount infiltrated
+#'  into the soil for the current day in millimetres.
 #' @param Scheduling
-#' Single integer number defining the number of days between two consecutive irrigations.
+#' Single integer number defining the number of days between two consecutive
+#'  irrigations.
 #' @param start.date
 #' Date at which the accounting should start. Formats:
 #' \dQuote{YYYY-MM-DD}, \dQuote{YYYY/MM/DD}.
 #' @return
 #' Water balance accounting, including the soil water deficit.
 #' @export
-#' @importFrom lubridate year is.Date
 #' @examples
-#' data(DataForCWB)
-#' Tavg <- DataForCWB[,2]
-#' Tmax <- DataForCWB[,3]
-#' Tmin <- DataForCWB[,4]
-#' Rn <- DataForCWB[,6]
-#' WS <- DataForCWB[,7]
-#' RH <- DataForCWB[,8]
-#' G <- DataForCWB[,9]
-#' ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-#' Rain <- DataForCWB[,10]
-#' Drz <- DataForCWB[,11]
-#' AWC <- DataForCWB[,12]
-#' MAD <- DataForCWB[,13]
-#' Kc <- DataForCWB[,14]
-#' Irrig <- DataForCWB[,15]
+#'
+#' Tavg <- DataForCWB[, 2]
+#' Tmax <- DataForCWB[, 3]
+#' Tmin <- DataForCWB[, 4]
+#' Rn <- DataForCWB[, 6]
+#' WS <- DataForCWB[, 7]
+#' RH <- DataForCWB[, 8]
+#' G <- DataForCWB[, 9]
+#' ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+#' Rain <- DataForCWB[, 10]
+#' Drz <- DataForCWB[, 11]
+#' AWC <- DataForCWB[, 12]
+#' MAD <- DataForCWB[, 13]
+#' Kc <- DataForCWB[, 14]
+#' Irrig <- DataForCWB[, 15]
 #' Scheduling <- 5
-#' CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz,
-#'     Kc=Kc, Irrig=Irrig, MAD=MAD, Scheduling=Scheduling, start.date = "2023-11-23")
+#' CWB_FixedSchedule(
+#'   Rain = Rain,
+#'   ET0 = ET0,
+#'   AWC = AWC,
+#'   Drz = Drz,
+#'   Kc = Kc,
+#'   Irrig = Irrig,
+#'   MAD = MAD,
+#'   Scheduling = Scheduling,
+#'   start.date = "2023-11-23"
+#' )
 
 CWB_FixedSchedule <- function(Rain,
-                          ET0,
-                          AWC,
-                          Drz,
-                          Kc = NULL,
-                          Irrig = NULL,
-                          MAD = NULL,
-                          InitialD = 0,
-                          Scheduling,
-                          start.date){
-  if (!is.numeric(Scheduling) || length(Scheduling) != 1 || Scheduling < 1) {
+                              ET0,
+                              AWC,
+                              Drz,
+                              Kc = NULL,
+                              Irrig = NULL,
+                              MAD = NULL,
+                              InitialD = 0,
+                              Scheduling,
+                              start.date) {
+  if (!is.numeric(Scheduling) ||
+      length(Scheduling) != 1 || Scheduling < 1) {
     stop("Scheduling must be a single positive number")
   }
-  if (Scheduling > 20){
+  if (Scheduling > 20) {
     message("Period between irrigations is longer than 20 days. Sure about it?")
   }
   Rain <- as.matrix(Rain)
   if (!is.numeric(Rain) || any(is.na(Rain)) ||
-      length(Rain[Rain<0]) != 0 || ncol(Rain) != 1){
-    stop("Physically impossible or missing rain values")}
+      length(Rain[Rain < 0]) != 0 || ncol(Rain) != 1) {
+    stop("Physically impossible or missing rain values")
+  }
   n <- length(Rain)
   start.date <- .check_date(start.date)
-  Ks <- matrix(1,n,1)
-  ETactul <- matrix(NA,n,1)
-  Arm <- matrix(NA,n,1)
-  Alt <- matrix(NA,n,1)
-  Exd <- matrix(NA,n,1)
-  Def <- matrix(NA,n,1)
-  NegAc <- matrix(NA,n,1)
-  P_ETc <- matrix(NA,n,1)
-  D <- matrix(NA,n,1)
-  recom <- matrix(NA,n,1)
-  if (is.null(Kc)) {Kc <- matrix(1,n,1)} else {Kc <- as.matrix(Kc)}
-  if (is.null(MAD)) {MAD <- matrix(0.3,n,1)} else {MAD <- as.matrix(MAD)}
-  if (is.null(Irrig)) {Irrig <- matrix(0,n,1)} else {Irrig <- as.matrix(Irrig)}
+  Ks <- matrix(1, n, 1)
+  ETactul <- matrix(NA, n, 1)
+  Arm <- matrix(NA, n, 1)
+  Alt <- matrix(NA, n, 1)
+  Exd <- matrix(NA, n, 1)
+  Def <- matrix(NA, n, 1)
+  NegAc <- matrix(NA, n, 1)
+  P_ETc <- matrix(NA, n, 1)
+  D <- matrix(NA, n, 1)
+  recom <- matrix(NA, n, 1)
+  if (is.null(Kc)) {
+    Kc <- matrix(1, n, 1)
+  } else {
+    Kc <- as.matrix(Kc)
+  }
+  if (is.null(MAD)) {
+    MAD <- matrix(0.3, n, 1)
+  } else {
+    MAD <- as.matrix(MAD)
+  }
+  if (is.null(Irrig)) {
+    Irrig <- matrix(0, n, 1)
+  } else {
+    Irrig <- as.matrix(Irrig)
+  }
   ET0 <- as.matrix(ET0)
   Drz <- as.matrix(Drz)
   if (!is.numeric(Kc) || length(Kc) != n || any(is.na(Kc)) ||
       !is.numeric(ET0) || length(ET0) != n || any(is.na(ET0)) ||
-      !is.numeric(Irrig) || length(Irrig) != n || any(is.na(Irrig)) ||
+      !is.numeric(Irrig) ||
+      length(Irrig) != n || any(is.na(Irrig)) ||
       !is.numeric(AWC) || length(AWC) != n || any(is.na(AWC)) ||
       !is.numeric(MAD) || length(MAD) != n || any(is.na(MAD)) ||
-      length(MAD[MAD>1]) != 0 || length(MAD[MAD<0])!= 0 ||
-      length(AWC[AWC<=0])!= 0 ||
+      length(MAD[MAD > 1]) != 0 || length(MAD[MAD < 0]) != 0 ||
+      length(AWC[AWC <= 0]) != 0 ||
       !is.numeric(Drz) || length(Drz) != n || any(is.na(Drz)) ||
-      length(Irrig[Irrig<0]) != 0 || length(ET0[ET0<0]) != 0 ||
-      length(Drz[Drz<0]) != 0 || length(Drz[Drz<0]) != 0 ||
+      length(Irrig[Irrig < 0]) != 0 || length(ET0[ET0 < 0]) != 0 ||
+      length(Drz[Drz < 0]) != 0 || length(Drz[Drz < 0]) != 0 ||
       length(Kc[Kc < 0.1]) != 0 || length(Kc[Kc > 3]) != 0 ||
-      ncol(Drz) != 1 || ncol(Kc) != 1 || ncol(MAD) != 1 || ncol(ET0) != 1)
-  {stop("Inputs must be numerical variables with no missing value.
-        Also check if the input are physically sound.")}
-  ETc <-ET0*Kc
-  TAW <- matrix((AWC*Drz),n,1)
-  dmad <- matrix((MAD*TAW),n,1)
+      ncol(Drz) != 1 ||
+      ncol(Kc) != 1 || ncol(MAD) != 1 || ncol(ET0) != 1)
+  {
+    stop(
+      "Inputs must be numerical variables with no missing value.
+        Also check if the input are physically sound."
+    )
+  }
+  ETc <- ET0 * Kc
+  TAW <- matrix((AWC * Drz), n, 1)
+  dmad <- matrix((MAD * TAW), n, 1)
   RainIrrig <- Rain + Irrig
   DaysSeason <- as.matrix(seq(1:n))
-  P_ETc[,1] <- RainIrrig[,1]-ETc[,1]
+  P_ETc[, 1] <- RainIrrig[, 1] - ETc[, 1]
 
   if (!is.numeric(InitialD) || length(InitialD) != 1 ||
-      InitialD > TAW[1,1] || InitialD < 0)
-  {stop("InitialD must be a single positive number no larger than TAW")}
-  D[1,1] <- InitialD + ETc[1,1] - RainIrrig[1,1]
-  if(D[1,1] < 0){D[1,1] <- 0}
-  if(D[1,1] > TAW[1,1]){D[1,1] <- TAW[1,1]}
-  if (D[1,1] > dmad[1,1]) {Ks[1,1] <- ((TAW[1,1]-D[1,1])/((1-MAD[1,1])*TAW[1,1]))}
+      InitialD > TAW[1, 1] || InitialD < 0)
+  {
+    stop("InitialD must be a single positive number no larger than TAW")
+  }
+  D[1, 1] <- InitialD + ETc[1, 1] - RainIrrig[1, 1]
+  if (D[1, 1] < 0) {
+    D[1, 1] <- 0
+  }
+  if (D[1, 1] > TAW[1, 1]) {
+    D[1, 1] <- TAW[1, 1]
+  }
+  if (D[1, 1] > dmad[1, 1]) {
+    Ks[1, 1] <- ((TAW[1, 1] - D[1, 1]) / ((1 - MAD[1, 1]) * TAW[1, 1]))
+  }
   days.irrig <- 1
   if (days.irrig == Scheduling) {
-    recom[1,1] <- paste0("Time to Irrigate", round(D[1, 1], 0), "mm")
-    days.irrig <- 1}
+    recom[1, 1] <- paste0("Time to Irrigate", round(D[1, 1], 0), "mm")
+    days.irrig <- 1
+  }
   else {
-    recom[1,1]=c("No")
-    days.irrig <- days.irrig+1}
-  for (i in 2:n){
-    D[i,1] <- D[(i-1),1] + ETc[i,1] - RainIrrig[i,1]
-    if(D[i,1] < 0){D[i,1] <- 0}
-    if(D[i,1] > TAW[i,1]){D[i,1] <- TAW[i,1]}
+    recom[1, 1] <- c("No")
+    days.irrig <- days.irrig + 1
+  }
+  for (i in 2:n) {
+    D[i, 1] <- D[(i - 1), 1] + ETc[i, 1] - RainIrrig[i, 1]
+    if (D[i, 1] < 0) {
+      D[i, 1] <- 0
+    }
+    if (D[i, 1] > TAW[i, 1]) {
+      D[i, 1] <- TAW[i, 1]
+    }
     if (days.irrig == Scheduling) {
-      recom[i,1]=paste("Time to Irrigate", round(D[i, 1], 0), "mm")
-      days.irrig <- 1}
+      recom[i, 1] <- paste("Time to Irrigate", round(D[i, 1], 0), "mm")
+      days.irrig <- 1
+    }
     else {
-      recom[i,1]=c("No")
-      days.irrig <- days.irrig+1}
-    if (D[i,1] >= dmad[i,1]) {Ks[i,1] <- ((TAW[i,1]-D[i,1])/((1-MAD[i,1])*TAW[i,1]))}
+      recom[i, 1] <- c("No")
+      days.irrig <- days.irrig + 1
+    }
+    if (D[i, 1] >= dmad[i, 1]) {
+      Ks[i, 1] <- ((TAW[i, 1] - D[i, 1]) / ((1 - MAD[i, 1]) * TAW[i, 1]))
+    }
   }
 
-  ETactul[,1] <- ETc[,1]*Ks[,1]
-  Def[,1] <- ETc[,1] - ETactul[,1]
-  WB=data.frame(DaysSeason,Rain,Irrig,ET0,Kc,Ks,ETc,P_ETc,ETactul,Def,TAW,D,dmad,recom)
-  WB[,2:13] <- round(WB[,2:13],3)
-  colnames(WB) <- c("DaysSeason","Rain","Irrig","ET0","Kc","WaterStressCoef_Ks","ETc", "(P+Irrig)-ETc","NonStandardCropEvap",
-                    "ET_Defict","TAW","SoilWaterDeficit","d_MAD", "Scheduling")
+  ETactul[, 1] <- ETc[, 1] * Ks[, 1]
+  Def[, 1] <- ETc[, 1] - ETactul[, 1]
+  WB <- data.frame(DaysSeason,
+                  Rain,
+                  Irrig,
+                  ET0,
+                  Kc,
+                  Ks,
+                  ETc,
+                  P_ETc,
+                  ETactul,
+                  Def,
+                  TAW,
+                  D,
+                  dmad,
+                  recom)
+  WB[, 2:13] <- round(WB[, 2:13], 3)
+  colnames(WB) <-
+    c(
+      "DaysSeason",
+      "Rain",
+      "Irrig",
+      "ET0",
+      "Kc",
+      "WaterStressCoef_Ks",
+      "ETc",
+      "(P+Irrig)-ETc",
+      "NonStandardCropEvap",
+      "ET_Defict",
+      "TAW",
+      "SoilWaterDeficit",
+      "d_MAD",
+      "Scheduling"
+    )
   start.cycle <- as.Date(start.date)
   end.cycle <- start.cycle + (n - 1)
   all.period <- seq(start.cycle, end.cycle, "days")

--- a/R/DataForCWB.R
+++ b/R/DataForCWB.R
@@ -18,7 +18,8 @@
 #'    \item{G}{Soil Heat Flux  in \acronym{MJ m-2 day-1}}
 #'    \item{Rain}{Rain in millimetres}
 #'    \item{Drz}{Depth of the root zone in metres}
-#'    \item{AWC}{available water capacity (amount of water between field capacity and permanent wilting point)
+#'    \item{AWC}{available water capacity (amount of water between field
+#'              capacity and permanent wilting point)
 #'               in millimetre of water per metre of soil}
 #'    \item{MAD}{management allowed depletion (between 0 and 1)}
 #'    \item{Kc}{Crop coefficient (between 0 and 1)}

--- a/R/DataForSWC.R
+++ b/R/DataForSWC.R
@@ -10,10 +10,14 @@
 #'  A data frame with 5 columns and 9 rows:
 #'  \describe{
 #'    \item{Soil type}{Soil Type}
-#'    \item{Teta_FC_Min}{Minimum values for soil water content at field capacity}
-#'    \item{Teta_FC_Max}{Maximum values for soil water content at field capacity}
-#'    \item{Teta_PWP_Min}{Minimum values for soil water content at permanent wilting point}
-#'    \item{Teta_PWP_Max}{Maximum values for soil water content at permanent wilting point}
+#'    \item{Teta_FC_Min}{Minimum values for soil water content at field
+#'       capacity}
+#'    \item{Teta_FC_Max}{Maximum values for soil water content at field
+#'      capacity}
+#'    \item{Teta_PWP_Min}{Minimum values for soil water content at permanent
+#'      wilting point}
+#'    \item{Teta_PWP_Max}{Maximum values for soil water content at permanent
+#'      wilting point}
 #'    }
 #'    @source <https://www.fao.org/home/en/>
 "DataForSWC"

--- a/R/Descriptive.R
+++ b/R/Descriptive.R
@@ -20,8 +20,7 @@
 #'  }
 #'
 #' @examples
-#' data(DataForCWB)
-#' Rain <- DataForCWB[,10]
+#' Rain <- DataForCWB[, 10]
 #' Descriptive(Sample = Rain)
 #' @export
 #' @importFrom PowerSDI Accuracy

--- a/R/ET0_HS.R
+++ b/R/ET0_HS.R
@@ -1,6 +1,7 @@
 #' Reference 'evapotranspiration' Using Hargreaves-Samani Method
 #'
-#' Calculates daily reference evapotranspiration amounts using the Hargreaves-Samani method.
+#' Calculates daily reference evapotranspiration amounts using the
+#'   Hargreaves-Samani method.
 #'
 #' @param Ra
 #' A `vector`, 1-column `matrix` or `data.frame` with extraterrestrial solar

--- a/R/ET0_PM.R
+++ b/R/ET0_PM.R
@@ -82,7 +82,9 @@ ET0_PM <- function(Tavg, Tmax, Tmin, Rn, RH, WS, G = NULL, Alt) {
     length(Tmax) != n || length(Tmin) != n || length(Rn) != n ||
     length(RH) != n || length(WS) != n || length(G) != n ||
     length(Alt) != 1 || Alt < 0 || !is.numeric(Alt)) {
-    stop("Physically impossible or missing Tmax, Tmin, Rn, RH, WS, G or Alt values")
+    stop(
+      "Physically impossible or missing Tmax, Tmin, Rn, RH, WS, G or Alt values"
+      )
   }
   es <- 0.6108 * exp((17.27 * Tavg) / (Tavg + 273.3))
   ea <- (RH * es) / 100

--- a/R/ET0_PT.R
+++ b/R/ET0_PT.R
@@ -19,6 +19,7 @@
 #' @return
 #' A matrix object of the daily potential evapotranspiration values in
 #'  millimetres.
+#'
 #' @export
 #' @examples
 #' # See `?DataForCWB` for more on this data set
@@ -26,6 +27,7 @@
 #' Rn <- DataForCWB[, 6]
 #' G <- DataForCWB[, 9]
 #' ET0_PT(Tavg = Tavg, Rn = Rn, G = G)
+#'
 ET0_PT <- function(Tavg, Rn, G = NULL, Coeff = 1.26) {
   Tavg <- as.matrix(Tavg)
   if (!is.numeric(Tavg) || any(is.na(Tavg)) ||

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,0 +1,526 @@
+---
+editor_options: 
+  markdown: 
+    wrap: sentence
+output: github_document
+---
+
+<!-- badges: start -->
+
+[![R-CMD-check](https://github.com/gabrielblain/CropWaterBalance/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/gabrielblain/CropWaterBalance/actions/workflows/R-CMD-check.yaml) <!-- badges: end -->
+
+# CropWaterBalance
+
+Crop water balance accounting in the root zone for irrigation purposes.
+
+# Basic Description
+
+{CropWaterBalance} is an R package designed to assist users in irrigation scheduling based on the Water Balance Approach.
+The package is capable of calculating reference evapotranspiration (ET0) through various methods and conducting crop water balance accounting.
+Additionally, {CropWaterBalance} includes auxiliary functions for comparing different ET0 estimation methods, calculating descriptive statistics for ET0 and rainfall series, and estimating soil heat flux and water stress coefficient.
+The functions `ET0_HS()`, `ET0_PT()`, and `ET0_PM()` are used to estimate daily ET0 amounts using the methods of Hargreaves-Samani, Priestley-Taylor, and FAO-56 Penman-Monteith, respectively.
+The `Descriptive()` function is specifically designed to calculate descriptive statistics for ET0 and rainfall series, including sample mean, median, standard deviation, standard error, maximum value, minimum value, and frequency of zeros.
+Additionally, the `Compare()` function may be used to calculate measures of accuracy and agreement between two ET0 or rainfall series.
+The `Soil_Heat_Flux()` function uses average air temperature data to estimate the soil heat flux, and the `Water_Stress_Coef()` function calculates the water stress coefficient for a crop.
+The package depends on R (\>= 2.10) and imports functions from the R packages {[PowerSDI](https://CRAN.R-project.org/package=PowerSDI/)} and {[lubridate](https://CRAN.R-project.org/package=lubridate)}.
+
+# Installation
+
+``` r
+devtools::install_github("gabrielblain/CropWaterBalance")
+```
+
+# Basic Instructions
+
+```{r, echo=FALSE, include=FALSE}
+# Load the library for examples below (not included in output)
+library(CropWaterBalance)
+```
+
+## Function ET0_PM()
+
+Calculates daily reference evapotranspiration amounts using the Penman and Monteith method.
+
+## Usage
+
+```{r, eval=FALSE}
+ET0_PM(Tavg,
+       Tmax,
+       Tmin,
+       Rn,
+       RH,
+       WS,
+       G = NULL,
+       Alt)
+```
+
+## Arguments
+
+-   Tavg: A vector, 1-column matrix or data frame with daily average air temperature.
+-   Tmax: A vector, 1-column matrix or data frame with daily maximum air temperature in Celsius degrees.
+-   Tmin: A vector, 1-column matrix or data frame with daily minimum air temperature in Celsius degrees.
+-   Rn: A vector, 1-column matrix or data frame with daily net radiation in MJ M-2 DAY-1.
+-   RH: A vector, 1-column matrix or data frame with daily relative Humidity in %.
+-   WS: A vector, 1-column matrix or data frame with daily wind speed in M S-1.
+-   G: Optional. A vector, 1-column matrix or data frame with daily soil heat flux in MJ M-2 DAY-1. Default is `NULL` and if `NULL` it is assumed to be zero. May be provided by Soil_Heat_Flux.
+-   Alt: A single number defining the altitude at crop's location in metres.
+
+## Value
+
+Daily reference evapotranspiration amounts in millimetres.
+
+## Examples
+
+```{r}
+Tavg <- DataForCWB[, 2]
+Tmax <- DataForCWB[, 3]
+Tmin <- DataForCWB[, 4]
+Rn <- DataForCWB[, 6]
+WS <- DataForCWB[, 7]
+RH <- DataForCWB[, 8]
+G <- DataForCWB[, 9]
+head(ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700))
+```
+
+## Function ET0_PT()
+
+Calculates daily reference evapotranspiration amounts using the Priestley-Taylor method.
+
+## Usage
+
+```{r, eval=FALSE}
+ET0_PT(Tavg,
+       Rn,
+       G = NULL,
+       Coeff = 1.26)
+```
+
+## Arguments
+
+-   Tavg: A vector, 1-column matrix or data frame with daily average air temperature.
+-   Rn: A vector, 1-column matrix or data frame with daily net radiation in MJ M-2 DAY-1.
+-   G: Optional. A vector, 1-column matrix or data frame with daily soil heat flux in MJ M-2 DAY-1. Default is `NULL` and if `NULL` it is assumed to be zero. May be provided by Soil_Heat_Flux
+-   Coeff: Single number defining the Priestley-Taylor coefficient. Default is 1.26
+
+## Value
+
+Daily reference evapotranspiration amounts in millimetres.
+
+## Examples
+
+```{r}
+Tavg <- DataForCWB[, 2]
+Rn <- DataForCWB[, 6]
+G <- DataForCWB[, 9]
+head(ET0_PT(Tavg, Rn, G))
+```
+
+## Function ET0_HS()
+
+Calculates daily reference evapotranspiration amounts using the Hargreaves-Samani method.
+
+## Usage
+
+```{r, eval=FALSE}
+ET0_HS(Ra,
+       Tavg,
+       Tmax,
+       Tmin)
+```
+
+## Arguments
+
+-   Ra: A vector, 1-column matrix or data frame with daily net radiation in MJ M-2 DAY-1.
+-   Tavg: A vector, 1-column matrix or data frame with daily average air temperature.
+-   Tmax: A vector, 1-column matrix or data frame with daily maximum air temperature in Celsius degrees.
+-   Tmin: A vector, 1-column matrix or data frame with daily minimum air temperature in Celsius degrees.
+
+## Value
+
+Daily reference evapotranspiration amounts in millimetres.
+
+## Examples
+
+```{r}
+Tavg <- DataForCWB[, 2]
+Tmax <- DataForCWB[, 3]
+Tmin <- DataForCWB[, 4]
+Ra <- DataForCWB[, 5]
+head(ET0_HS(
+  Ra = Ra,
+  Tavg = Tavg,
+  Tmax = Tmax,
+  Tmin = Tmin
+))
+```
+
+## Function Soil_Heat_Flux()
+
+Calculates the daily amounts of Soil Heat Flux.
+
+## Usage
+
+```{r, eval=FALSE}
+Soil_Heat_Flux(Tavg) 
+```
+
+## Arguments
+
+-   Tavg: A vector, 1-column matrix or data frame with daily average air temperature.
+
+## Value
+
+Daily amounts of soil Heat flux in MJ m-2 day-1.
+
+## Examples
+
+```{r}
+Tavg <- DataForCWB[, 2]
+head(Soil_Heat_Flux(Tavg))
+```
+
+## Function Descriptive()
+
+Calculates descriptive statistics for rainfall, evapotranspiration, or other variable.
+
+## Usage
+
+```{r, eval=FALSE}
+Descriptive(Sample)
+```
+
+## Arguments
+
+-   Sample: A vector, 1-column matrix or data frame with rainfall, evapotranspiration, or other variable.
+    ## Value
+
+-   sample mean (Avg), sample median (Med), sample standard variation (SD), sample standard Error (SE), maximum value (MaxValue), minimum value (MinValue), and frequency of zeros (FreqZero%) \## Examples
+
+## Examples
+
+```{r}
+Rain <- DataForCWB[, 10]
+Descriptive(Sample = Rain)
+```
+
+## Function Compare()
+
+Calculates measures of accuracy and agreement.
+
+## Usage
+
+```{r, eval=FALSE}
+Compare(Sample1, Sample2)
+```
+
+## Arguments
+
+-   Sample1: A vector, 1-column matrix or data frame with evapotranspiration or other variable.
+-   Sample2: A vector, 1-column matrix or data frame with evapotranspiration or other variable.
+
+## Value
+
+-   Absolute mean error (AME), Square root of the mean squared error (RMSE), Willmott's indices of agreement: original (dorig), Modified (dmod) and refined (dref), Pearson determination coefficient (R2).
+
+## Examples
+
+```{r}
+Tavg <- DataForCWB[, 2]
+Tmax <- DataForCWB[, 3]
+Tmin <- DataForCWB[, 4]
+Rn <- DataForCWB[, 6]
+WS <- DataForCWB[, 7]
+RH <- DataForCWB[, 8]
+G <- DataForCWB[, 9]
+Sample1 <-
+  ET0_PM(
+    Tavg = Tavg,
+    Tmax = Tmax,
+    Tmin = Tmin,
+    Rn = Rn,
+    RH = RH,
+    WS = WS,
+    G = G,
+    Alt = 700
+  )
+Sample2 <- ET0_PT(Tavg = Tavg, Rn = Rn, G = G)
+Compare(Sample1 = Sample1, Sample2 = Sample2)
+```
+
+## Function CWB()
+
+Calculates several parameters of the crop water balance.
+It also suggests when and how much to irrigate.
+
+## Usage
+
+```{r, eval=FALSE}
+CWB(
+  Rain,
+  ET0,
+  AWC,
+  Drz,
+  Kc = NULL,
+  Irrig = NULL,
+  MAD = NULL,
+  InitialD = 0,
+  start.date
+)
+```
+
+## Arguments
+
+-   Rain: Vector, 1-column matrix or data frame with daily rainfall totals in millimetres.
+
+-   ET0: Vector, 1-column matrix or data frame with daily reference evapotranspiration in millimetres.
+
+-   AWC: Vector, 1-column matrix or data frame with the available water capacity of the soil, that is: the amount of water between field capacity and permanent wilting point in millimetres of water per centimetre of soil.
+
+-   Drz: Vector, 1-column matrix or data frame defining the root zone depth in centimetres.
+
+-   Kc: Vector, 1-column matrix or data frame defining the crop coefficient.
+    If NULL its values are assumed to be 1.
+
+-   Irrig: Vector, 1-column matrix or data frame with net irrigation amount infiltrated into the soil for the current day in millimetres.
+
+-   MAD: Vector, 1-column matrix or data frame defining the management allowed depletion.
+    Varies between 0 and 1.
+
+-   InitialD Single number defining in millimetre, the initial soil water deficit.
+    It is used to start the water balance accounting.
+    Default value is 0, which assumes the root zone is at the field capacity.
+
+-   start.date: Date at which the accounting should start.
+    Formats: “YYYY-MM-DD”, “YYYY/MM/DD”.
+
+## Value
+
+-   Water balance accounting, including the soil water deficit.
+
+## Examples
+
+```{r}
+Tavg <- DataForCWB[, 2]
+Tmax <- DataForCWB[, 3]
+Tmin <- DataForCWB[, 4]
+Rn <- DataForCWB[, 6]
+WS <- DataForCWB[, 7]
+RH <- DataForCWB[, 8]
+G <- DataForCWB[, 9]
+ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+Rain <- DataForCWB[, 10]
+Drz <- DataForCWB[, 11]
+AWC <- DataForCWB[, 12]
+MAD <- DataForCWB[, 13]
+Kc <- DataForCWB[, 14]
+Irrig <- DataForCWB[, 15]
+head(CWB(
+  Rain = Rain,
+  ET0 = ET0,
+  AWC = AWC,
+  Drz = Drz,
+  Kc = Kc,
+  Irrig = Irrig,
+  MAD = MAD,
+  start.date = "2023-11-23"
+))
+```
+
+## Function CWB_FixedSchedule()
+
+Calculates several parameters of the crop water balance.
+It also suggests how much irrigate.
+
+## Usage
+
+```{r, eval=FALSE}
+CWB_FixedSchedule(
+  Rain,
+  ET0,
+  AWC,
+  Drz,
+  Kc = NULL,
+  Irrig = NULL,
+  MAD = NULL,
+  InitialD = 0,
+  Scheduling,
+  start.date
+)
+```
+
+## Arguments
+
+-   Rain: Vector, 1-column matrix or data frame with daily rainfall totals in millimetres.
+
+-   ET0: Vector, 1-column matrix or data frame with daily reference evapotranspiration in millimetres.
+
+-   AWC: Vector, 1-column matrix or data frame with the available water capacity of the soil, that is: the amount of water between field capacity and permanent wilting point in millimetre of water per centimetre of soil.
+
+-   Drz: Vector, 1-column matrix or data frame defining the root zone depth in centimetres.
+
+-   Kc: Vector, 1-column matrix or data frame defining the crop coefficient.
+    If NULL its values are assumed to be 1.
+
+-   Irrig: Vector, 1-column matrix or data frame with net irrigation amount infiltrated into the soil for the current day in millimetres.
+
+-   MAD: Vector, 1-column matrix or data frame defining the management allowed depletion.
+    Varies between 0 and 1.
+
+-   InitialD Single number defining in millimetre, the initial soil water deficit.
+    It is used to start the water balance accounting.
+    Default value is 0, which assumes the root zone is at the field capacity.
+
+-   Scheduling Single integer number defining the number of days between two consecutive irrigations.
+
+-   start.date: Date at which the accounting should start.
+    Formats: “YYYY-MM-DD”, “YYYY/MM/DD”.
+
+## Value
+
+-   Water balance accounting, including the soil water deficit.
+
+```{r}
+Tavg <- DataForCWB[, 2]
+Tmax <- DataForCWB[, 3]
+Tmin <- DataForCWB[, 4]
+Rn <- DataForCWB[, 6]
+WS <- DataForCWB[, 7]
+RH <- DataForCWB[, 8]
+G <- DataForCWB[, 9]
+ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+Rain <- DataForCWB[, 10]
+Drz <- DataForCWB[, 11]
+AWC <- DataForCWB[, 12]
+MAD <- DataForCWB[, 13]
+Kc <- DataForCWB[, 14]
+Irrig <- DataForCWB[, 15]
+Scheduling <- 5
+head(CWB_FixedSchedule(
+  Rain = Rain,
+  ET0 = ET0,
+  AWC = AWC,
+  Drz = Drz,
+  Kc = Kc,
+  Irrig = Irrig,
+  MAD = MAD,
+  Scheduling = Scheduling,
+  start.date = "2023-11-23"
+))
+```
+
+## DataForAWC: Soil texture and plant available water capacity (AWC).
+
+AWC is the amount of water between field capacity and permanent wilting point.
+Given in millimetre of water per centimetre of soil.
+Extracted from: Irrigation Scheduling: The Water Balance Approach Fact Sheet No. 4.707 by A.
+A. Andales, J. L. Chávez, T. A. Bauder..
+
+## Usage
+
+```{r, eval=FALSE}
+DataForAWC
+```
+
+## Format
+
+-   Soil Texture Soil Texture
+-   AWC Low Available water capacity in millimetre of water per centimetre of soil
+-   AWC High Available water capacity in millimetre of water per centimetre of soil
+-   AWC Average Available water capacity in millimetre of water per centimetre of soil
+
+## Source
+
+<https://extension.colostate.edu/topic-areas/agriculture/>.
+
+## Examples
+
+```{r}
+DataForAWC
+```
+
+## DataForCWB: Data for Water Balance Accounting.
+
+Daily meteorological data from a weather station in Campinas, Brazil and other parameters required for calculating the crop water balance.
+The meteorological data belongs to the Agronomic Institute of the state of Sao Paulo.
+
+## Usage
+
+```{r, eval=FALSE}
+DataForCWB
+```
+
+## Format
+
+-   A data frame with 129 rows and 16 columns.
+-   date date
+-   tmed Average air temperature in Celsius degrees
+-   tmax Maximum air temperature in Celsius degrees
+-   tmin Minimum air temperature in Celsius degrees
+-   Ra Extraterrestrial solar radiation in MJ M-2 DAY-1
+-   Rn Net radiation in MJ M-2 DAY-1
+-   W Wind speed in M S-1
+-   RH Relative Humidity in %
+-   G Soil Heat Flux in MJ M-2 DAY-1
+-   Rain Rain in millimetres
+-   Drz Depth of the root zone in centimetres
+-   AWC available water capacity (amount of water between field capacity and permanent wilting point) in millimetre of water per centimetre of soil
+-   MAD management allowed depletion (between 0 and 1)
+-   Kc Crop coefficient (between 0 and 1)
+-   Irrig Applied net irrigation in millimetres
+
+## Source
+
+<http://www.ciiagro.org.br/>.
+
+## Examples
+
+```{r}
+head(DataForCWB)
+```
+
+## BugReports:
+
+\<<https://github.com/gabrielblain/CropWaterBalance/issues> \>
+
+## License:
+
+MIT
+
+## Authors:
+
+Gabriel Constantino Blain, Graciela da Rocha Sobierajski, Regina Célia Matos Pires, Adam H. Sparks, Letícia L. Martins.
+Maintainer: Gabriel Constantino Blain, [gabriel.blain\@sp.gov.br](mailto:gabriel.blain@sp.gov.br){.email}
+
+## Acknowledgments:
+
+The package uses data from the Fact Sheet number 4707 Irrigation Scheduling: The Water Balance Approach, by A.
+A. Andales, J. L. Chávez, and T.
+A. Bauder.
+The authors greatly appreciate this initiative.
+
+## References
+
+Allen, R.G.; Pereira, L.S.; Raes, D.; Smith, M. Crop evapotranspiration.
+In Guidelines for Computing Crop Water Requirements.
+Irrigation and Drainage Paper 56; FAO: Rome, Italy, 1998; p. 300.
+
+Andales, A.A.; Chávez, J.L.;Bauder, T.A.
+2012.
+Irrigation Scheduling: The Water Balance Approach.
+Fact Sheet number 4707, crop series \| irrigation.
+<https://extension.colostate.edu/docs/pubs/crops/04707.pdf>
+
+Hargreaves, G.H.; Samani, Z.A.
+1985.Reference crop evapotranspiration from temperature.
+Appl.
+Eng.
+Agric,1, 96–99.
+
+Package ‘lubridate', Version 1.9.3, Author Vitalie Spinu et al., <https://CRAN.R-project.org/package=lubridate>
+
+Package ‘PowerSDI', Version 1.0.
+0, Author Gabriel C. Blain et al., <https://CRAN.R-project.org/package=PowerSDI>
+
+Priestley, C.H.B., Taylor, R.J., 1972.
+On the Assessment of Surface Heat Flux and Evaporation Using Large-Scale Parameters.
+Monthly Weather Review, 100 (2), 81–92.

--- a/README.md
+++ b/README.md
@@ -1,276 +1,434 @@
+
 <!-- badges: start -->
-  [![R-CMD-check](https://github.com/gabrielblain/CropWaterBalance/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/gabrielblain/CropWaterBalance/actions/workflows/R-CMD-check.yaml)
-  <!-- badges: end -->
-  
+
+[![R-CMD-check](https://github.com/gabrielblain/CropWaterBalance/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/gabrielblain/CropWaterBalance/actions/workflows/R-CMD-check.yaml)
+<!-- badges: end -->
+
 # CropWaterBalance
+
 Crop water balance accounting in the root zone for irrigation purposes.
 
 # Basic Description
-The CropWaterBalance is an R package designed to assist users in irrigation scheduling based on the Water Balance Approach.
-The package is capable of calculating reference evapotranspiration (ET0) through various methods and conducting crop water balance accounting. Additionally, CropWaterBalance includes auxiliary functions for comparing different ET0 estimation methods, calculating descriptive statistics for ET0 and rainfall series, and estimating soil heat flux and water stress coefficient. 
-The functions ET0_HS(), ET0_PT(), and ET0_PM() are used to estimate daily ET0 amounts using the methods of Hargreaves-Samani, Priestley-Taylor, and FAO-56 Penman-Monteith, respectively.
-The Descriptive() function is specifically designed to calculate descriptive statistics for ET0 and rainfall series, including sample mean, median, standard deviation, standard error, maximum value, minimum value, and frequency of zeros. Additionally, the Compare() function may be used to calculate measures of accuracy and agreement between two ET0 or rainfall series.
-The Soil_Heat_Flux() function uses average air temperature data to estimate the soil heat flux, and the Water_Stress_Coef() function calculates the water stress coefficient for a crop.
-The package depends on R (>= 2.10) and imports functions from the R packages {[PowerSDI]( https://CRAN.R-project.org/package=PowerSDI/)} and {[lubridate]( https://CRAN.R-project.org/package=lubridate)}.
+
+{CropWaterBalance} is an R package designed to assist users in
+irrigation scheduling based on the Water Balance Approach. The package
+is capable of calculating reference evapotranspiration (ET0) through
+various methods and conducting crop water balance accounting.
+Additionally, {CropWaterBalance} includes auxiliary functions for
+comparing different ET0 estimation methods, calculating descriptive
+statistics for ET0 and rainfall series, and estimating soil heat flux
+and water stress coefficient. The functions `ET0_HS()`, `ET0_PT()`, and
+`ET0_PM()` are used to estimate daily ET0 amounts using the methods of
+Hargreaves-Samani, Priestley-Taylor, and FAO-56 Penman-Monteith,
+respectively. The `Descriptive()` function is specifically designed to
+calculate descriptive statistics for ET0 and rainfall series, including
+sample mean, median, standard deviation, standard error, maximum value,
+minimum value, and frequency of zeros. Additionally, the `Compare()`
+function may be used to calculate measures of accuracy and agreement
+between two ET0 or rainfall series. The `Soil_Heat_Flux()` function uses
+average air temperature data to estimate the soil heat flux, and the
+`Water_Stress_Coef()` function calculates the water stress coefficient
+for a crop. The package depends on R (\>= 2.10) and imports functions
+from the R packages
+{[PowerSDI](https://CRAN.R-project.org/package=PowerSDI/)} and
+{[lubridate](https://CRAN.R-project.org/package=lubridate)}.
 
 # Installation
 
-```r
+``` r
 devtools::install_github("gabrielblain/CropWaterBalance")
 ```
 
 # Basic Instructions
 
 ## Function ET0_PM()
-Calculates daily reference evapotranspiration amounts using the Penman and Monteith method.
+
+Calculates daily reference evapotranspiration amounts using the Penman
+and Monteith method.
 
 ## Usage
-```r
+
+``` r
 ET0_PM(Tavg,
-Tmax,
-Tmin,
-Rn,
-RH,
-WS,
-G = NULL,
-Alt)
+       Tmax,
+       Tmin,
+       Rn,
+       RH,
+       WS,
+       G = NULL,
+       Alt)
 ```
 
 ## Arguments
 
-* Tavg: A vector, 1-column matrix or data frame with daily average air temperature.
-* Tmax: A vector, 1-column matrix or data frame with daily maximum air temperature
-in Celsius degrees.
-* Tmin: A vector, 1-column matrix or data frame with daily minimum air temperature in
-Celsius degrees.
-* Rn: A vector, 1-column matrix or data frame with daily net radiation in MJ M-2 DAY-1.
-* RH: A vector, 1-column matrix or data frame with daily relative Humidity in %.
-* WS: A vector, 1-column matrix or data frame with daily wind speed in M S-1.
-* G: Optional. A vector, 1-column matrix or data frame with daily soil heat flux in
-MJ M-2 DAY-1. Default is `NULL` and if `NULL` it is assumed to be zero.
-May be provided by Soil_Heat_Flux.
-* Alt: A single number defining the altitude at crop's location in metres.
+- Tavg: A vector, 1-column matrix or data frame with daily average air
+  temperature.
+- Tmax: A vector, 1-column matrix or data frame with daily maximum air
+  temperature in Celsius degrees.
+- Tmin: A vector, 1-column matrix or data frame with daily minimum air
+  temperature in Celsius degrees.
+- Rn: A vector, 1-column matrix or data frame with daily net radiation
+  in MJ M-2 DAY-1.
+- RH: A vector, 1-column matrix or data frame with daily relative
+  Humidity in %.
+- WS: A vector, 1-column matrix or data frame with daily wind speed in M
+  S-1.
+- G: Optional. A vector, 1-column matrix or data frame with daily soil
+  heat flux in MJ M-2 DAY-1. Default is `NULL` and if `NULL` it is
+  assumed to be zero. May be provided by Soil_Heat_Flux.
+- Alt: A single number defining the altitude at crop’s location in
+  metres.
+
 ## Value
 
 Daily reference evapotranspiration amounts in millimetres.
+
 ## Examples
 
-```r
-data(DataForCWB)
-Tavg <- DataForCWB[,2]
-Tmax <- DataForCWB[,3]
-Tmin <- DataForCWB[,4]
-Rn <- DataForCWB[,6]
-WS <- DataForCWB[,7]
-RH <- DataForCWB[,8]
-G <- DataForCWB[,9]
-ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt = 700)
+``` r
+Tavg <- DataForCWB[, 2]
+Tmax <- DataForCWB[, 3]
+Tmin <- DataForCWB[, 4]
+Rn <- DataForCWB[, 6]
+WS <- DataForCWB[, 7]
+RH <- DataForCWB[, 8]
+G <- DataForCWB[, 9]
+head(ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700))
 ```
+
+    ##        ET0_PM
+    ## [1,] 2.440372
+    ## [2,] 4.171917
+    ## [3,] 4.290477
+    ## [4,] 3.665459
+    ## [5,] 4.848520
+    ## [6,] 5.669878
 
 ## Function ET0_PT()
-Calculates daily reference evapotranspiration amounts using the Priestley-Taylor method.
+
+Calculates daily reference evapotranspiration amounts using the
+Priestley-Taylor method.
 
 ## Usage
-```r
-ET0_PT(
-Tavg,
-Rn,
-G = NULL, 
-Coeff = 1.26) 
+
+``` r
+ET0_PT(Tavg,
+       Rn,
+       G = NULL,
+       Coeff = 1.26)
 ```
 
 ## Arguments
 
-* Tavg: A vector, 1-column matrix or data frame with daily average air temperature.
-* Rn: A vector, 1-column matrix or data frame with daily net radiation in MJ M-2 DAY-1.
-* G: Optional. A vector, 1-column matrix or data frame with daily soil heat flux in
-MJ M-2 DAY-1. Default is `NULL` and if `NULL` it is assumed to be zero.
-May be provided by Soil_Heat_Flux
-* Coeff: Single number defining the Priestley-Taylor coefficient. Default is 1.26
+- Tavg: A vector, 1-column matrix or data frame with daily average air
+  temperature.
+- Rn: A vector, 1-column matrix or data frame with daily net radiation
+  in MJ M-2 DAY-1.
+- G: Optional. A vector, 1-column matrix or data frame with daily soil
+  heat flux in MJ M-2 DAY-1. Default is `NULL` and if `NULL` it is
+  assumed to be zero. May be provided by Soil_Heat_Flux
+- Coeff: Single number defining the Priestley-Taylor coefficient.
+  Default is 1.26
+
 ## Value
 
 Daily reference evapotranspiration amounts in millimetres.
+
 ## Examples
 
-```r
-data(DataForCWB)
-Tavg <- DataForCWB[,2]
-Rn <- DataForCWB[,6]
-G <- DataForCWB[,9]
-ET0_PT(Tavg, Rn,G) 
+``` r
+Tavg <- DataForCWB[, 2]
+Rn <- DataForCWB[, 6]
+G <- DataForCWB[, 9]
+head(ET0_PT(Tavg, Rn, G))
 ```
+
+    ##        ET0_PT
+    ## [1,] 3.432709
+    ## [2,] 5.849554
+    ## [3,] 6.432616
+    ## [4,] 5.695334
+    ## [5,] 7.023900
+    ## [6,] 7.817355
 
 ## Function ET0_HS()
-Calculates daily reference evapotranspiration amounts using the Hargreaves-Samani method.
+
+Calculates daily reference evapotranspiration amounts using the
+Hargreaves-Samani method.
 
 ## Usage
-```r
-ET0_HS(
-Ra,
-Tavg,
-Tmax,
-Tmin
-) 
+
+``` r
+ET0_HS(Ra,
+       Tavg,
+       Tmax,
+       Tmin)
 ```
 
 ## Arguments
 
-* Ra: A vector, 1-column matrix or data frame with daily net radiation in MJ M-2 DAY-1.
-* Tavg: A vector, 1-column matrix or data frame with daily average air temperature.
-* Tmax: A vector, 1-column matrix or data frame with daily maximum air temperature
-in Celsius degrees.
-* Tmin: A vector, 1-column matrix or data frame with daily minimum air temperature in
-Celsius degrees.
+- Ra: A vector, 1-column matrix or data frame with daily net radiation
+  in MJ M-2 DAY-1.
+- Tavg: A vector, 1-column matrix or data frame with daily average air
+  temperature.
+- Tmax: A vector, 1-column matrix or data frame with daily maximum air
+  temperature in Celsius degrees.
+- Tmin: A vector, 1-column matrix or data frame with daily minimum air
+  temperature in Celsius degrees.
+
 ## Value
 
 Daily reference evapotranspiration amounts in millimetres.
+
 ## Examples
 
-```r
-data(DataForCWB)
-Tavg <- DataForCWB[,2]
-Tmax <- DataForCWB[,3]
-Tmin <- DataForCWB[,4]
-Ra <- DataForCWB[,5]
-ET0_HS(Ra=Ra, Tavg=Tavg, Tmax=Tmax, Tmin=Tmin) 
+``` r
+Tavg <- DataForCWB[, 2]
+Tmax <- DataForCWB[, 3]
+Tmin <- DataForCWB[, 4]
+Ra <- DataForCWB[, 5]
+head(ET0_HS(
+  Ra = Ra,
+  Tavg = Tavg,
+  Tmax = Tmax,
+  Tmin = Tmin
+))
 ```
 
+    ##           ET0
+    ## [1,] 4.703700
+    ## [2,] 5.331592
+    ## [3,] 5.664174
+    ## [4,] 6.163377
+    ## [5,] 5.291303
+    ## [6,] 6.251883
+
 ## Function Soil_Heat_Flux()
+
 Calculates the daily amounts of Soil Heat Flux.
 
 ## Usage
-```r
+
+``` r
 Soil_Heat_Flux(Tavg) 
 ```
 
 ## Arguments
 
-* Tavg: A vector, 1-column matrix or data frame with daily average air temperature.
+- Tavg: A vector, 1-column matrix or data frame with daily average air
+  temperature.
+
 ## Value
 
 Daily amounts of soil Heat flux in MJ m-2 day-1.
+
 ## Examples
 
-```r
-data(DataForCWB)
-Tavg <- DataForCWB[,2]
-Soil_Heat_Flux(Tavg) 
+``` r
+Tavg <- DataForCWB[, 2]
+head(Soil_Heat_Flux(Tavg))
 ```
 
+    ## Warning in Soil_Heat_Flux(Tavg): The first 3 G values were set to zero
+
+    ##            [,1]
+    ## [1,]  0.0000000
+    ## [2,]  0.0000000
+    ## [3,]  0.0000000
+    ## [4,]  0.3806333
+    ## [5,] -0.7796333
+    ## [6,] -0.2007667
+
 ## Function Descriptive()
-Calculates descriptive statistics for rainfall, evapotranspiration, or other variable.
+
+Calculates descriptive statistics for rainfall, evapotranspiration, or
+other variable.
 
 ## Usage
-```r
+
+``` r
 Descriptive(Sample)
 ```
 
 ## Arguments
 
-* Sample: A vector, 1-column matrix or data frame with rainfall, evapotranspiration, or other variable.
-## Value
+- Sample: A vector, 1-column matrix or data frame with rainfall,
+  evapotranspiration, or other variable. \## Value
 
-* sample mean (Avg), sample median (Med), sample standard variation (SD), sample standard Error (SE), maximum value (MaxValue), minimum value (MinValue), and frequency of zeros (FreqZero%)
+- sample mean (Avg), sample median (Med), sample standard variation
+  (SD), sample standard Error (SE), maximum value (MaxValue), minimum
+  value (MinValue), and frequency of zeros (FreqZero%) \## Examples
+
 ## Examples
 
-```r
-data(DataForCWB)
-Rain <- DataForCWB[,10]
+``` r
+Rain <- DataForCWB[, 10]
 Descriptive(Sample = Rain)
 ```
 
+    ##   SampleSize  Avg  Med    SD   SE MaxValue MinValue FreqZero%
+    ## 1        129 6.53 0.25 13.06 1.15    71.37        0     48.06
+
 ## Function Compare()
+
 Calculates measures of accuracy and agreement.
 
 ## Usage
-```r
+
+``` r
 Compare(Sample1, Sample2)
 ```
 
 ## Arguments
 
-* Sample1: A vector, 1-column matrix or data frame with evapotranspiration or other variable.
-* Sample2: A vector, 1-column matrix or data frame with evapotranspiration or other variable.
+- Sample1: A vector, 1-column matrix or data frame with
+  evapotranspiration or other variable.
+- Sample2: A vector, 1-column matrix or data frame with
+  evapotranspiration or other variable.
+
 ## Value
 
-* Absolute mean error (AME), Square root of the mean squared error (RMSE), Willmott's indices of agreement: original (dorig), Modified (dmod) and refined (dref), Pearson determination coefficient (R2).
+- Absolute mean error (AME), Square root of the mean squared error
+  (RMSE), Willmott’s indices of agreement: original (dorig), Modified
+  (dmod) and refined (dref), Pearson determination coefficient (R2).
+
 ## Examples
 
-```r
-data(DataForCWB)
-Tavg <- DataForCWB[,2]
-Tmax <- DataForCWB[,3]
-Tmin <- DataForCWB[,4]
-Rn <- DataForCWB[,6]
-WS <- DataForCWB[,7]
-RH <- DataForCWB[,8]
-G <- DataForCWB[,9]
-Sample1 <- ET0_PM(Tavg=Tavg, Tmax=Tmax, Tmin=Tmin, Rn=Rn, RH=RH, WS=WS,G=G)
-Sample2 <- ET0_PT(Tavg=Tavg, Rn=Rn,G=G)
-Compare(Sample1=Sample1, Sample2=Sample2)
+``` r
+Tavg <- DataForCWB[, 2]
+Tmax <- DataForCWB[, 3]
+Tmin <- DataForCWB[, 4]
+Rn <- DataForCWB[, 6]
+WS <- DataForCWB[, 7]
+RH <- DataForCWB[, 8]
+G <- DataForCWB[, 9]
+Sample1 <-
+  ET0_PM(
+    Tavg = Tavg,
+    Tmax = Tmax,
+    Tmin = Tmin,
+    Rn = Rn,
+    RH = RH,
+    WS = WS,
+    G = G,
+    Alt = 700
+  )
+Sample2 <- ET0_PT(Tavg = Tavg, Rn = Rn, G = G)
+Compare(Sample1 = Sample1, Sample2 = Sample2)
 ```
 
+    ##       AME     RMSE     dorig     dmod        dref     RQuad
+    ## 1 1.69222 1.813449 0.6403158 0.376103 -0.05737454 0.8675223
+
 ## Function CWB()
-Calculates several parameters of the crop water balance. It also suggests when and how much to irrigate.
+
+Calculates several parameters of the crop water balance. It also
+suggests when and how much to irrigate.
 
 ## Usage
 
-```r
+``` r
 CWB(
-Rain,
-ET0,
-AWC,
-Drz,
-Kc = NULL,
-Irrig = NULL,
-MAD = NULL,
-InitialD = 0,
-start.date
+  Rain,
+  ET0,
+  AWC,
+  Drz,
+  Kc = NULL,
+  Irrig = NULL,
+  MAD = NULL,
+  InitialD = 0,
+  start.date
 )
 ```
 
 ## Arguments
 
-* Rain: Vector, 1-column matrix or data frame with daily rainfall totals in millimetres.
-* ET0: Vector, 1-column matrix or data frame with daily reference evapotranspiration in millimetres.
-* AWC: Vector, 1-column matrix or data frame with the available water capacity of the soil, that is: the amount of water between field capacity and permanent wilting point in millimetre of water per centimetre of soil.
-* Drz: Vector, 1-column matrix or data frame defining the root zone depth in centimetres.
-* Kc: Vector, 1-column matrix or data frame defining the crop coefficient. If NULL its values are assumed to be 1.
-* Irrig: Vector, 1-column matrix or data frame with net irrigation amount infiltrated into the soil for the current day in millimetres.
-* MAD: Vector, 1-column matrix or data frame defining the management allowed depletion. Varies between 0 and 1.
-* InitialD Single number defining in millimetre, the initial soil water deficit. It is used to start the water balance accounting. Default value is 0, which assumes the root zone is at the field capacity.
-* start.date: Date at which the accounting should start. Formats: “YYYY-MM-DD”, “YYYY/MM/DD”.
+- Rain: Vector, 1-column matrix or data frame with daily rainfall totals
+  in millimetres.
+
+- ET0: Vector, 1-column matrix or data frame with daily reference
+  evapotranspiration in millimetres.
+
+- AWC: Vector, 1-column matrix or data frame with the available water
+  capacity of the soil, that is: the amount of water between field
+  capacity and permanent wilting point in millimetres of water per
+  centimetre of soil.
+
+- Drz: Vector, 1-column matrix or data frame defining the root zone
+  depth in centimetres.
+
+- Kc: Vector, 1-column matrix or data frame defining the crop
+  coefficient. If NULL its values are assumed to be 1.
+
+- Irrig: Vector, 1-column matrix or data frame with net irrigation
+  amount infiltrated into the soil for the current day in millimetres.
+
+- MAD: Vector, 1-column matrix or data frame defining the management
+  allowed depletion. Varies between 0 and 1.
+
+- InitialD Single number defining in millimetre, the initial soil water
+  deficit. It is used to start the water balance accounting. Default
+  value is 0, which assumes the root zone is at the field capacity.
+
+- start.date: Date at which the accounting should start. Formats:
+  “YYYY-MM-DD”, “YYYY/MM/DD”.
+
 ## Value
 
-* Water balance accounting, including the soil water deficit.
+- Water balance accounting, including the soil water deficit.
+
 ## Examples
 
-```r
-data(DataForCWB)
-Tavg <- DataForCWB[,2]
-Tmax <- DataForCWB[,3]
-Tmin <- DataForCWB[,4]
-Rn <- DataForCWB[,6]
-WS <- DataForCWB[,7]
-RH <- DataForCWB[,8]
-G <- DataForCWB[,9]
+``` r
+Tavg <- DataForCWB[, 2]
+Tmax <- DataForCWB[, 3]
+Tmin <- DataForCWB[, 4]
+Rn <- DataForCWB[, 6]
+WS <- DataForCWB[, 7]
+RH <- DataForCWB[, 8]
+G <- DataForCWB[, 9]
 ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
-Rain <- DataForCWB[,10]
-Drz <- DataForCWB[,11]
-AWC <- DataForCWB[,12]
-MAD <- DataForCWB[,13]
-Kc <- DataForCWB[,14]
-Irrig <- DataForCWB[,15]
-CWB(Rain = Rain, ET0 = ET0, AWC = AWC, Drz = Drz,
-    Kc = Kc, Irrig = Irrig, MAD = MAD, start.date = "2023-11-23")
+Rain <- DataForCWB[, 10]
+Drz <- DataForCWB[, 11]
+AWC <- DataForCWB[, 12]
+MAD <- DataForCWB[, 13]
+Kc <- DataForCWB[, 14]
+Irrig <- DataForCWB[, 15]
+head(CWB(
+  Rain = Rain,
+  ET0 = ET0,
+  AWC = AWC,
+  Drz = Drz,
+  Kc = Kc,
+  Irrig = Irrig,
+  MAD = MAD,
+  start.date = "2023-11-23"
+))
 ```
 
+    ##            DaysSeason Rain Irrig ET0 Kc WaterStressCoef_Ks ETc (P+Irrig)-ETc
+    ## 2023-11-22          1 45.5     0 2.4  1                  1 2.4          43.0
+    ## 2023-11-23          2  0.3     0 4.2  1                  1 4.2          -3.9
+    ## 2023-11-24          3  0.0     0 4.3  1                  1 4.3          -4.3
+    ## 2023-11-25          4 11.4     0 3.7  1                  1 3.7           7.8
+    ## 2023-11-26          5  0.3     0 4.8  1                  1 4.8          -4.6
+    ## 2023-11-27          6  0.0     0 5.7  1                  1 5.7          -5.7
+    ##            NonStandardCropEvap ET_Defict  TAW SoilWaterDeficit d_MAD D>=dmad
+    ## 2023-11-22                 2.4         0 45.7              0.0  13.7      No
+    ## 2023-11-23                 4.2         0 45.7              3.9  13.7      No
+    ## 2023-11-24                 4.3         0 45.7              8.2  13.7      No
+    ## 2023-11-25                 3.7         0 45.7              0.4  13.7      No
+    ## 2023-11-26                 4.8         0 45.7              5.0  13.7      No
+    ## 2023-11-27                 5.7         0 45.7             10.7  13.7      No
+
 ## Function CWB_FixedSchedule()
-Calculates several parameters of the crop water balance. It also suggests how much irrigate.
+
+Calculates several parameters of the crop water balance. It also
+suggests how much irrigate.
 
 ## Usage
 
-```r
+``` r
 CWB_FixedSchedule(
   Rain,
   ET0,
@@ -287,129 +445,239 @@ CWB_FixedSchedule(
 
 ## Arguments
 
-* Rain: Vector, 1-column matrix or data frame with daily rainfall totals in millimetres.
-* ET0: Vector, 1-column matrix or data frame with daily reference evapotranspiration in millimetres.
-* AWC: Vector, 1-column matrix or data frame with the available water capacity of the soil, that is: the amount of water between field capacity and permanent wilting point in millimetre of water per centimetre of soil.
-* Drz: Vector, 1-column matrix or data frame defining the root zone depth in centimetres.
-* Kc: Vector, 1-column matrix or data frame defining the crop coefficient. If NULL its values are assumed to be 1.
-* Irrig: Vector, 1-column matrix or data frame with net irrigation amount infiltrated into the soil for the current day in millimetres.
-* MAD: Vector, 1-column matrix or data frame defining the management allowed depletion. Varies between 0 and 1.
-* InitialD Single number defining in millimetre, the initial soil water deficit. It is used to start the water balance accounting. Default value is 0, which assumes the root zone is at the field capacity.
-* Scheduling Single integer number defining the number of days between two consecutive irrigations.
-* start.date: Date at which the accounting should start. Formats: “YYYY-MM-DD”, “YYYY/MM/DD”.
+- Rain: Vector, 1-column matrix or data frame with daily rainfall totals
+  in millimetres.
+
+- ET0: Vector, 1-column matrix or data frame with daily reference
+  evapotranspiration in millimetres.
+
+- AWC: Vector, 1-column matrix or data frame with the available water
+  capacity of the soil, that is: the amount of water between field
+  capacity and permanent wilting point in millimetre of water per
+  centimetre of soil.
+
+- Drz: Vector, 1-column matrix or data frame defining the root zone
+  depth in centimetres.
+
+- Kc: Vector, 1-column matrix or data frame defining the crop
+  coefficient. If NULL its values are assumed to be 1.
+
+- Irrig: Vector, 1-column matrix or data frame with net irrigation
+  amount infiltrated into the soil for the current day in millimetres.
+
+- MAD: Vector, 1-column matrix or data frame defining the management
+  allowed depletion. Varies between 0 and 1.
+
+- InitialD Single number defining in millimetre, the initial soil water
+  deficit. It is used to start the water balance accounting. Default
+  value is 0, which assumes the root zone is at the field capacity.
+
+- Scheduling Single integer number defining the number of days between
+  two consecutive irrigations.
+
+- start.date: Date at which the accounting should start. Formats:
+  “YYYY-MM-DD”, “YYYY/MM/DD”.
+
 ## Value
 
-* Water balance accounting, including the soil water deficit.
-## Examples
+- Water balance accounting, including the soil water deficit.
 
-```r
-data(DataForCWB)
-Tavg <- DataForCWB[,2]
-Tmax <- DataForCWB[,3]
-Tmin <- DataForCWB[,4]
-Rn <- DataForCWB[,6]
-WS <- DataForCWB[,7]
-RH <- DataForCWB[,8]
-G <- DataForCWB[,9]
-ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-Rain <- DataForCWB[,10]
-Drz <- DataForCWB[,11]
-AWC <- DataForCWB[,12]
-MAD <- DataForCWB[,13]
-Kc <- DataForCWB[,14]
-Irrig <- DataForCWB[,15]
+``` r
+Tavg <- DataForCWB[, 2]
+Tmax <- DataForCWB[, 3]
+Tmin <- DataForCWB[, 4]
+Rn <- DataForCWB[, 6]
+WS <- DataForCWB[, 7]
+RH <- DataForCWB[, 8]
+G <- DataForCWB[, 9]
+ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+Rain <- DataForCWB[, 10]
+Drz <- DataForCWB[, 11]
+AWC <- DataForCWB[, 12]
+MAD <- DataForCWB[, 13]
+Kc <- DataForCWB[, 14]
+Irrig <- DataForCWB[, 15]
 Scheduling <- 5
-CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz,
-    Kc=Kc, Irrig=Irrig, MAD=MAD, Scheduling=Scheduling, start.date = "2023-11-23")
+head(CWB_FixedSchedule(
+  Rain = Rain,
+  ET0 = ET0,
+  AWC = AWC,
+  Drz = Drz,
+  Kc = Kc,
+  Irrig = Irrig,
+  MAD = MAD,
+  Scheduling = Scheduling,
+  start.date = "2023-11-23"
+))
 ```
+
+    ##            DaysSeason   Rain Irrig   ET0 Kc WaterStressCoef_Ks   ETc
+    ## 2023-11-22          1 45.470     0 2.440  1                  1 2.440
+    ## 2023-11-23          2  0.254     0 4.172  1                  1 4.172
+    ## 2023-11-24          3  0.000     0 4.290  1                  1 4.290
+    ## 2023-11-25          4 11.430     0 3.665  1                  1 3.665
+    ## 2023-11-26          5  0.254     0 4.849  1                  1 4.849
+    ## 2023-11-27          6  0.000     0 5.670  1                  1 5.670
+    ##            (P+Irrig)-ETc NonStandardCropEvap ET_Defict   TAW SoilWaterDeficit
+    ## 2023-11-22        43.030               2.440         0 45.72            0.000
+    ## 2023-11-23        -3.918               4.172         0 45.72            3.918
+    ## 2023-11-24        -4.290               4.290         0 45.72            8.208
+    ## 2023-11-25         7.765               3.665         0 45.72            0.444
+    ## 2023-11-26        -4.595               4.849         0 45.72            5.038
+    ## 2023-11-27        -5.670               5.670         0 45.72           10.708
+    ##             d_MAD            Scheduling
+    ## 2023-11-22 13.716                    No
+    ## 2023-11-23 13.716                    No
+    ## 2023-11-24 13.716                    No
+    ## 2023-11-25 13.716                    No
+    ## 2023-11-26 13.716 Time to Irrigate 5 mm
+    ## 2023-11-27 13.716                    No
 
 ## DataForAWC: Soil texture and plant available water capacity (AWC).
 
-AWC is the amount of water between field capacity and permanent wilting point. Given in millimetre of water per centimetre of soil. Extracted from: Irrigation Scheduling: The Water Balance Approach Fact Sheet No. 4.707 by A. A. Andales, J. L. Chávez, T. A. Bauder..
+AWC is the amount of water between field capacity and permanent wilting
+point. Given in millimetre of water per centimetre of soil. Extracted
+from: Irrigation Scheduling: The Water Balance Approach Fact Sheet
+No. 4.707 by A. A. Andales, J. L. Chávez, T. A. Bauder..
 
 ## Usage
 
-```r
+``` r
 DataForAWC
 ```
 
 ## Format
-* Soil Texture Soil Texture
-* AWC Low Available water capacity in millimetre of water per centimetre of soil
-* AWC High Available water capacity in millimetre of water per centimetre of soil
-* AWC Average Available water capacity in millimetre of water per centimetre of soil
+
+- Soil Texture Soil Texture
+- AWC Low Available water capacity in millimetre of water per centimetre
+  of soil
+- AWC High Available water capacity in millimetre of water per
+  centimetre of soil
+- AWC Average Available water capacity in millimetre of water per
+  centimetre of soil
 
 ## Source
 
-https://extension.colostate.edu/topic-areas/agriculture/.
+<https://extension.colostate.edu/topic-areas/agriculture/>.
 
 ## Examples
 
-```r
-data(DataForAWC)
+``` r
+DataForAWC
 ```
+
+    ##        Soil.Texture AWC.Low AWC.High AWC.Average
+    ## 1      Coarse sands      50       70          60
+    ## 2        Fine sands      70       80          80
+    ## 3       Loamy sands      70      100          80
+    ## 4       Sandy loams     100      130         120
+    ## 5  Fine sandy loams     130      170         150
+    ## 6  Sandy clay loams     130      180         160
+    ## 7             Loams     180      210         200
+    ## 8        Silt loams     170      210         190
+    ## 9  Silty clay loams     130      170         150
+    ## 10        Clay loam     130      170         150
+    ## 11       Silty clay     130      140         130
+    ## 12             Clay     110      130         120
 
 ## DataForCWB: Data for Water Balance Accounting.
 
-Daily meteorological data from a weather station in Campinas, Brazil and other parameters required for calculating the crop water balance. The meteorological data belongs to the Agronomic Institute of the state of Sao Paulo.
+Daily meteorological data from a weather station in Campinas, Brazil and
+other parameters required for calculating the crop water balance. The
+meteorological data belongs to the Agronomic Institute of the state of
+Sao Paulo.
 
-## Usage 
+## Usage
 
+``` r
 DataForCWB
+```
 
 ## Format
 
-* A data frame with 129 rows and 16 columns.
-* date date
-* tmed Average air temperature in Celsius degrees
-* tmax Maximum air temperature in Celsius degrees
-* tmin Minimum air temperature in Celsius degrees
-* Ra Extraterrestrial solar radiation in MJ M-2 DAY-1
-* Rn Net radiation in MJ M-2 DAY-1
-* W Wind speed in M S-1
-* RH Relative Humidity in %
-* G Soil Heat Flux in MJ M-2 DAY-1
-* Rain Rain in millimetres
-* Drz Depth of the root zone in centimetres
-* AWC available water capacity (amount of water between field capacity and permanent wilting point) in millimetre of water per centimetre of soil
-* MAD management allowed depletion (between 0 and 1)
-* Kc Crop coefficient (between 0 and 1)
-* Irrig Applied net irrigation in millimetres
+- A data frame with 129 rows and 16 columns.
+- date date
+- tmed Average air temperature in Celsius degrees
+- tmax Maximum air temperature in Celsius degrees
+- tmin Minimum air temperature in Celsius degrees
+- Ra Extraterrestrial solar radiation in MJ M-2 DAY-1
+- Rn Net radiation in MJ M-2 DAY-1
+- W Wind speed in M S-1
+- RH Relative Humidity in %
+- G Soil Heat Flux in MJ M-2 DAY-1
+- Rain Rain in millimetres
+- Drz Depth of the root zone in centimetres
+- AWC available water capacity (amount of water between field capacity
+  and permanent wilting point) in millimetre of water per centimetre of
+  soil
+- MAD management allowed depletion (between 0 and 1)
+- Kc Crop coefficient (between 0 and 1)
+- Irrig Applied net irrigation in millimetres
 
 ## Source
 
-http://www.ciiagro.org.br/.
+<http://www.ciiagro.org.br/>.
 
 ## Examples
 
-```r
-data(DataForCWB)
+``` r
+head(DataForCWB)
 ```
 
-## BugReports: 
-<https://github.com/gabrielblain/CropWaterBalance/issues >
+    ##         Date   tmed  tmax  tmin       Ra       Rn    W    RH     G   Rain
+    ## 1 11/23/2010 23.000 27.26 18.74 42.07246  6.04422 2.16 76.58 -0.64 45.470
+    ## 2 11/24/2010 23.730 29.00 18.46 42.12238 11.08968 2.57 64.50 -0.30  0.254
+    ## 3 11/25/2010 24.650 30.33 18.97 42.17043 12.71410 2.80 70.37  0.19  0.000
+    ## 4 11/26/2010 24.795 31.46 18.13 42.21660 11.46852 1.86 73.03  0.38 11.430
+    ## 5 11/27/2010 22.340 27.86 16.82 42.26093 12.89778 2.61 57.80 -0.78  0.254
+    ## 6 11/28/2010 23.400 30.70 16.10 42.30341 15.02158 2.42 48.06 -0.20  0.000
+    ##      Drz AWC MAD Kc Irrig
+    ## 1 0.3048 150 0.3  1     0
+    ## 2 0.3048 150 0.3  1     0
+    ## 3 0.3048 150 0.3  1     0
+    ## 4 0.3048 150 0.3  1     0
+    ## 5 0.3048 150 0.3  1     0
+    ## 6 0.3048 150 0.3  1     0
+
+## BugReports:
+
+\<<https://github.com/gabrielblain/CropWaterBalance/issues> \>
 
 ## License:
 
 MIT
 
-## Authors: 
-Gabriel Constantino Blain, Graciela da Rocha Sobierajski, Regina Célia Matos Pires, Adam H. Sparks, Letícia L. Martins. 
-Maintainer: Gabriel Constantino Blain, <gabriel.blain@sp.gov.br>
+## Authors:
+
+Gabriel Constantino Blain, Graciela da Rocha Sobierajski, Regina Célia
+Matos Pires, Adam H. Sparks, Letícia L. Martins. Maintainer: Gabriel
+Constantino Blain, <gabriel.blain@sp.gov.br>
 
 ## Acknowledgments:
-The package uses data from the Fact Sheet number 4707 Irrigation Scheduling: The Water Balance Approach, by A. A. Andales, J. L. Chávez, and T. A. Bauder.
-The authors greatly appreciate this initiative.
+
+The package uses data from the Fact Sheet number 4707 Irrigation
+Scheduling: The Water Balance Approach, by A. A. Andales, J. L. Chávez,
+and T. A. Bauder. The authors greatly appreciate this initiative.
 
 ## References
-Allen, R.G.; Pereira, L.S.; Raes, D.; Smith, M. Crop evapotranspiration. In Guidelines for Computing Crop Water Requirements. Irrigation and Drainage Paper 56; FAO: Rome, Italy, 1998; p. 300.
 
-Andales, A.A.; Chávez, J.L.;Bauder, T.A. 2012. Irrigation Scheduling: The Water Balance Approach. Fact Sheet number 4707, crop series | irrigation. <https://extension.colostate.edu/docs/pubs/crops/04707.pdf>
+Allen, R.G.; Pereira, L.S.; Raes, D.; Smith, M. Crop evapotranspiration.
+In Guidelines for Computing Crop Water Requirements. Irrigation and
+Drainage Paper 56; FAO: Rome, Italy, 1998; p. 300.
 
-Hargreaves, G.H.; Samani, Z.A. 1985.Reference crop evapotranspiration from temperature. Appl. Eng. Agric,1, 96–99.
+Andales, A.A.; Chávez, J.L.;Bauder, T.A. 2012. Irrigation Scheduling:
+The Water Balance Approach. Fact Sheet number 4707, crop series \|
+irrigation. <https://extension.colostate.edu/docs/pubs/crops/04707.pdf>
 
-Package ‘lubridate', Version 1.9.3, Author Vitalie Spinu et al., <https://CRAN.R-project.org/package=lubridate>
+Hargreaves, G.H.; Samani, Z.A. 1985.Reference crop evapotranspiration
+from temperature. Appl. Eng. Agric,1, 96–99.
 
-Package ‘PowerSDI', Version 1.0. 0, Author Gabriel C. Blain et al., <https://CRAN.R-project.org/package=PowerSDI>
+Package ‘lubridate’, Version 1.9.3, Author Vitalie Spinu et al.,
+<https://CRAN.R-project.org/package=lubridate>
 
-Priestley, C.H.B., Taylor, R.J., 1972. On the Assessment of Surface Heat Flux and Evaporation Using Large-Scale Parameters. Monthly Weather Review, 100 (2), 81–92.
+Package ‘PowerSDI’, Version 1.0. 0, Author Gabriel C. Blain et al.,
+<https://CRAN.R-project.org/package=PowerSDI>
+
+Priestley, C.H.B., Taylor, R.J., 1972. On the Assessment of Surface Heat
+Flux and Evaporation Using Large-Scale Parameters. Monthly Weather
+Review, 100 (2), 81–92.

--- a/codemeta.json
+++ b/codemeta.json
@@ -146,6 +146,7 @@
     },
     "SystemRequirements": null
   },
-  "fileSize": "161.253KB",
-  "readme": "https://github.com/gabrielblain/CropWaterBalance/blob/master/README.md"
+  "fileSize": "191.332KB",
+  "readme": "https://github.com/gabrielblain/CropWaterBalance/blob/master/README.md",
+  "contIntegration": "https://github.com/gabrielblain/CropWaterBalance/actions/workflows/R-CMD-check.yaml"
 }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -8,7 +8,6 @@ BugReports
 CMD
 CWB
 Chávez
-Coef
 Coeff
 Constantino
 CpsET
@@ -40,6 +39,7 @@ Paulo
 Pereira
 Pires
 PowerSDI
+PowerSDI’
 Preistley
 RQuad
 Raes
@@ -53,6 +53,7 @@ Tmin
 Vitalie
 WS
 Willmott's
+Willmott’s
 YYYY
 agrometeorological
 al
@@ -66,6 +67,7 @@ et
 evapotranspiration
 irrigations
 lubridate
+lubridate’
 metre
 metres
 millimetre

--- a/man/CWB.Rd
+++ b/man/CWB.Rd
@@ -55,7 +55,6 @@ Calculates several parameters of the crop water balance.  It also suggests
 when to irrigate.
 }
 \examples{
-data(DataForCWB)
 Tavg <- DataForCWB[,2]
 Tmax <- DataForCWB[,3]
 Tmin <- DataForCWB[,4]

--- a/man/CWB_FixedSchedule.Rd
+++ b/man/CWB_FixedSchedule.Rd
@@ -18,30 +18,33 @@ CWB_FixedSchedule(
 )
 }
 \arguments{
-\item{Rain}{Vector, 1-column matrix or data frame with daily rainfall totals in millimetres.}
+\item{Rain}{Vector, 1-column matrix or data frame with daily rainfall totals in
+millimetres.}
 
-\item{ET0}{Vector, 1-column matrix or data frame with daily reference evapotranspiration in millimetres.}
+\item{ET0}{Vector, 1-column matrix or data frame with daily reference evapotranspiration
+in millimetres.}
 
-\item{AWC}{Vector, 1-column matrix or data frame with the available water capacity of the soil, that is:
-the amount of water between field capacity and permanent wilting point
-in millimetre of water per metres of soil.}
+\item{AWC}{Vector, 1-column matrix or data frame with the available water capacity of
+the soil, that is: the amount of water between field capacity and permanent
+wilting point in millimetres of water per metres of soil.}
 
 \item{Drz}{Vector, 1-column matrix or data frame defining the root zone depth in metres.}
 
 \item{Kc}{Vector, 1-column matrix or data frame defining the crop coefficient.
 If NULL its values are assumed to be 1.}
 
-\item{Irrig}{Vector, 1-column matrix or data frame with net irrigation amount infiltrated into the soil
-for the current day in millimetres.}
+\item{Irrig}{Vector, 1-column matrix or data frame with net irrigation amount infiltrated
+into the soil for the current day in millimetres.}
 
-\item{MAD}{Vector, 1-column matrix or data frame defining the management allowed depletion.
-Varies between 0 and 1.}
+\item{MAD}{Vector, 1-column matrix or data frame defining the management allowed
+depletion.  Varies between 0 and 1.}
 
 \item{InitialD}{Single number defining in millimetre, the initial soil water deficit.
 It is used to start the water balance accounting.
 Default value is zero, which assumes the root zone is at the field capacity.}
 
-\item{Scheduling}{Single integer number defining the number of days between two consecutive irrigations.}
+\item{Scheduling}{Single integer number defining the number of days between two consecutive
+irrigations.}
 
 \item{start.date}{Date at which the accounting should start. Formats:
 \dQuote{YYYY-MM-DD}, \dQuote{YYYY/MM/DD}.}
@@ -54,22 +57,31 @@ Calculates several parameters of the crop water balance.
 It also suggests how much irrigate.
 }
 \examples{
-data(DataForCWB)
-Tavg <- DataForCWB[,2]
-Tmax <- DataForCWB[,3]
-Tmin <- DataForCWB[,4]
-Rn <- DataForCWB[,6]
-WS <- DataForCWB[,7]
-RH <- DataForCWB[,8]
-G <- DataForCWB[,9]
-ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-Rain <- DataForCWB[,10]
-Drz <- DataForCWB[,11]
-AWC <- DataForCWB[,12]
-MAD <- DataForCWB[,13]
-Kc <- DataForCWB[,14]
-Irrig <- DataForCWB[,15]
+
+Tavg <- DataForCWB[, 2]
+Tmax <- DataForCWB[, 3]
+Tmin <- DataForCWB[, 4]
+Rn <- DataForCWB[, 6]
+WS <- DataForCWB[, 7]
+RH <- DataForCWB[, 8]
+G <- DataForCWB[, 9]
+ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+Rain <- DataForCWB[, 10]
+Drz <- DataForCWB[, 11]
+AWC <- DataForCWB[, 12]
+MAD <- DataForCWB[, 13]
+Kc <- DataForCWB[, 14]
+Irrig <- DataForCWB[, 15]
 Scheduling <- 5
-CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz,
-    Kc=Kc, Irrig=Irrig, MAD=MAD, Scheduling=Scheduling, start.date = "2023-11-23")
+CWB_FixedSchedule(
+  Rain = Rain,
+  ET0 = ET0,
+  AWC = AWC,
+  Drz = Drz,
+  Kc = Kc,
+  Irrig = Irrig,
+  MAD = MAD,
+  Scheduling = Scheduling,
+  start.date = "2023-11-23"
+)
 }

--- a/man/DataForCWB.Rd
+++ b/man/DataForCWB.Rd
@@ -30,7 +30,8 @@ A data frame with 15 columns and 129 rows:
 \item{G}{Soil Heat Flux  in \acronym{MJ m-2 day-1}}
 \item{Rain}{Rain in millimetres}
 \item{Drz}{Depth of the root zone in metres}
-\item{AWC}{available water capacity (amount of water between field capacity and permanent wilting point)
+\item{AWC}{available water capacity (amount of water between field
+capacity and permanent wilting point)
 in millimetre of water per metre of soil}
 \item{MAD}{management allowed depletion (between 0 and 1)}
 \item{Kc}{Crop coefficient (between 0 and 1)}

--- a/man/DataForSWC.Rd
+++ b/man/DataForSWC.Rd
@@ -22,10 +22,14 @@ Irrigation and Drainage Paper 56; FAO: Rome, Italy, 1998; p. 300.
 A data frame with 5 columns and 9 rows:
 \describe{
 \item{Soil type}{Soil Type}
-\item{Teta_FC_Min}{Minimum values for soil water content at field capacity}
-\item{Teta_FC_Max}{Maximum values for soil water content at field capacity}
-\item{Teta_PWP_Min}{Minimum values for soil water content at permanent wilting point}
-\item{Teta_PWP_Max}{Maximum values for soil water content at permanent wilting point}
+\item{Teta_FC_Min}{Minimum values for soil water content at field
+capacity}
+\item{Teta_FC_Max}{Maximum values for soil water content at field
+capacity}
+\item{Teta_PWP_Min}{Minimum values for soil water content at permanent
+wilting point}
+\item{Teta_PWP_Max}{Maximum values for soil water content at permanent
+wilting point}
 }
 @source \url{https://www.fao.org/home/en/}
 }

--- a/man/Descriptive.Rd
+++ b/man/Descriptive.Rd
@@ -28,7 +28,6 @@ Calculates descriptive statistics for rainfall, evapotranspiration, or other
 variables.
 }
 \examples{
-data(DataForCWB)
-Rain <- DataForCWB[,10]
+Rain <- DataForCWB[, 10]
 Descriptive(Sample = Rain)
 }

--- a/man/ET0_HS.Rd
+++ b/man/ET0_HS.Rd
@@ -24,7 +24,8 @@ A \code{matrix} of 1-column with the same length as `the input values with the
 daily potential evapotranspiration values in millimetres.
 }
 \description{
-Calculates daily reference evapotranspiration amounts using the Hargreaves-Samani method.
+Calculates daily reference evapotranspiration amounts using the
+Hargreaves-Samani method.
 }
 \examples{
 # See `?DataForCWB` for more on this data set

--- a/man/ET0_PT.Rd
+++ b/man/ET0_PT.Rd
@@ -33,4 +33,5 @@ Tavg <- DataForCWB[, 2]
 Rn <- DataForCWB[, 6]
 G <- DataForCWB[, 9]
 ET0_PT(Tavg = Tavg, Rn = Rn, G = G)
+
 }

--- a/tests/testthat/test-CWB.R
+++ b/tests/testthat/test-CWB.R
@@ -46,10 +46,13 @@ test_that("CWB() works as expected in example", {
       "D>=dmad"
     )
   )
-  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372, 4.171917, 4.290477), tolerance = 0.01)
-  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000, 0.000000000, 0.000000000), tolerance = 0.01)
+  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372, 4.171917, 4.290477),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000, 0.000000000, 0.000000000),
+               tolerance = 0.01)
   expect_equal(tes[1:3, "TAW"], c(45.72, 45.72, 45.72), tolerance = 0.01)
-  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000, 3.9179166, 8.2083937), tolerance = 0.01)
+  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000, 3.9179166, 8.2083937),
+               tolerance = 0.01)
   expect_equal(tes[1:3, "d_MAD"], c(13.716, 13.716, 13.716), tolerance = 0.01)
   expect_equal(tes[1:3, "D>=dmad"], c("No", "No", "No"))
 })
@@ -88,10 +91,13 @@ test_that("CWB() works as expected when initialD is provided", {
       "D>=dmad"
     )
   )
-  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372, 4.171917, 4.290477), tolerance = 0.01)
-  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000, 0.000000000, 0.000000000), tolerance = 0.01)
+  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372, 4.171917, 4.290477),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000, 0.000000000, 0.000000000),
+               tolerance = 0.01)
   expect_equal(tes[1:3, "TAW"], c(45.72, 45.72, 45.72), tolerance = 0.01)
-  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000, 3.9179166, 8.2083937), tolerance = 0.01)
+  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000, 3.9179166, 8.2083937),
+               tolerance = 0.01)
   expect_equal(tes[1:3, "d_MAD"], c(13.716, 13.716, 13.716), tolerance = 0.01)
   expect_equal(tes[1:3, "D>=dmad"], c("No", "No", "No"))
 })
@@ -114,7 +120,6 @@ test_that("Wrong date format", {
 
 
 test_that("CWB() works as expected When Kc is NULL", {
-
   tes <- CWB(
     Rain = Rain,
     ET0 = ET0,
@@ -147,10 +152,13 @@ test_that("CWB() works as expected When Kc is NULL", {
       "D>=dmad"
     )
   )
-  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372, 4.171917, 4.290477), tolerance = 0.01)
-  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000, 0.000000000, 0.000000000), tolerance = 0.01)
+  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372, 4.171917, 4.290477),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000, 0.000000000, 0.000000000),
+               tolerance = 0.01)
   expect_equal(tes[1:3, "TAW"], c(45.72, 45.72, 45.72), tolerance = 0.01)
-  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000, 3.9179166, 8.2083937), tolerance = 0.01)
+  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000, 3.9179166, 8.2083937),
+               tolerance = 0.01)
   expect_equal(tes[1:3, "d_MAD"], c(13.716, 13.716, 13.716), tolerance = 0.01)
   expect_equal(tes[1:3, "D>=dmad"], c("No", "No", "No"))
 })
@@ -188,10 +196,13 @@ test_that("CWB() works as expected When Irrig is NULL", {
       "D>=dmad"
     )
   )
-  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372, 4.171917, 4.290477), tolerance = 0.01)
-  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000, 0.000000000, 0.000000000), tolerance = 0.01)
+  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372, 4.171917, 4.290477),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000, 0.000000000, 0.000000000),
+               tolerance = 0.01)
   expect_equal(tes[1:3, "TAW"], c(45.72, 45.72, 45.72), tolerance = 0.01)
-  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000, 3.9179166, 8.2083937), tolerance = 0.01)
+  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000, 3.9179166, 8.2083937),
+               tolerance = 0.01)
   expect_equal(tes[1:3, "d_MAD"], c(13.716, 13.716, 13.716), tolerance = 0.01)
   expect_equal(tes[1:3, "D>=dmad"], c("No", "No", "No"))
 })
@@ -229,16 +240,18 @@ test_that("CWB() works as expected When MAD is NULL", {
       "D>=dmad"
     )
   )
-  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372, 4.171917, 4.290477), tolerance = 0.01)
-  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000, 0.000000000, 0.000000000), tolerance = 0.01)
+  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372, 4.171917, 4.290477),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000, 0.000000000, 0.000000000),
+               tolerance = 0.01)
   expect_equal(tes[1:3, "TAW"], c(45.72, 45.72, 45.72), tolerance = 0.01)
-  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000, 3.9179166, 8.2083937), tolerance = 0.01)
+  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000, 3.9179166, 8.2083937),
+               tolerance = 0.01)
   expect_equal(tes[1:3, "d_MAD"], c(13.716, 13.716, 13.716), tolerance = 0.01)
   expect_equal(tes[1:3, "D>=dmad"], c("No", "No", "No"))
 })
 
 test_that("CWB() works as expected when G is NULL", {
-
   expect_warning(ET0 <-
                    ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, Alt = 700),
                  "The first 3 G values were set to zero")
@@ -274,16 +287,18 @@ test_that("CWB() works as expected when G is NULL", {
       "D>=dmad"
     )
   )
-  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.293183, 4.104242, 4.333359), tolerance = 0.01)
-  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000, 0.000000000, 0.000000000), tolerance = 0.01)
+  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.293183, 4.104242, 4.333359),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000, 0.000000000, 0.000000000),
+               tolerance = 0.01)
   expect_equal(tes[1:3, "TAW"], c(45.72, 45.72, 45.72), tolerance = 0.01)
-  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000, 3.8502425, 8.1836018), tolerance = 0.01)
+  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000, 3.8502425, 8.1836018),
+               tolerance = 0.01)
   expect_equal(tes[1:3, "d_MAD"], c(13.716, 13.716, 13.716), tolerance = 0.01)
   expect_equal(tes[1:3, "D>=dmad"], c("No", "No", "No"))
 })
 
 test_that("CWB() works as expected when P<ET0 on the very first day", {
-
   ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
   ET0 <- ET0[2:10]
   ET0 <- as.matrix(ET0)
@@ -326,10 +341,13 @@ test_that("CWB() works as expected when P<ET0 on the very first day", {
       "D>=dmad"
     )
   )
-  expect_equal(tes1[1:3, "NonStandardCropEvap"], c(4.171917, 4.290477, 3.665459), tolerance = 0.01)
-  expect_equal(tes1[1:3, "ET_Defict"], c(0.0000000, 0.0000000, 0.0000000), tolerance = 0.01)
+  expect_equal(tes1[1:3, "NonStandardCropEvap"],
+               c(4.171917, 4.290477, 3.665459), tolerance = 0.01)
+  expect_equal(tes1[1:3, "ET_Defict"], c(0.0000000, 0.0000000, 0.0000000),
+               tolerance = 0.01)
   expect_equal(tes1[1:3, "TAW"], c(45.72, 45.72, 45.72), tolerance = 0.01)
-  expect_equal(tes1[1:3, "SoilWaterDeficit"], c(3.9179166, 8.2083937, 0.4438527), tolerance = 0.01)
+  expect_equal(tes1[1:3, "SoilWaterDeficit"],
+               c(3.9179166, 8.2083937, 0.4438527), tolerance = 0.01)
   expect_equal(tes1[1:3, "d_MAD"], c(13.716, 13.716, 13.716), tolerance = 0.01)
   expect_equal(tes1[1:3, "D>=dmad"], c("No", "No", "No"))
 })
@@ -354,14 +372,16 @@ test_that("Missing rain values", {
   missing_Rain <- DataForCWB[, 10]
   missing_Rain[1] <- NA
   expect_error(
-    CWB(Rain = missing_Rain,
-        ET0,
-        AWC,
-        Drz,
-        Kc,
-        Ks,
-        Irrig,
-        start.date = "2023-11-23"),
+    CWB(
+      Rain = missing_Rain,
+      ET0,
+      AWC,
+      Drz,
+      Kc,
+      Ks,
+      Irrig,
+      start.date = "2023-11-23"
+    ),
     "Physically impossible or missing rain values"
   )
 })
@@ -369,15 +389,17 @@ test_that("Missing rain values", {
 test_that("Wrong format rain", {
   wrong_Rain <- cbind(DataForCWB[, 10], DataForCWB[, 10])
   expect_error(
-    CWB(Rain = wrong_Rain,
-        ET0,
-        AWC,
-        Drz,
-        Kc,
-        Ks,
-        Irrig,
-        MAD,
-        start.date = "2023-11-23"),
+    CWB(
+      Rain = wrong_Rain,
+      ET0,
+      AWC,
+      Drz,
+      Kc,
+      Ks,
+      Irrig,
+      MAD,
+      start.date = "2023-11-23"
+    ),
     "Physically impossible or missing rain values"
   )
 })
@@ -477,7 +499,6 @@ test_that("Physically impossible MAD values", {
 })
 
 test_that("Wrong MAD values. Single number", {
-
   wrong_MAD <- 4
   Kc <- DataForCWB[, 14]
   Irrig <- DataForCWB[, 15]
@@ -537,7 +558,6 @@ test_that("Wrong Drz values. Character", {
 })
 
 test_that("Physically impossible AWC values", {
-
   impossible_AWC <- AWC
   impossible_AWC[1] <- 0
   expect_error(

--- a/tests/testthat/test-CWB_FixedSchedule.R
+++ b/tests/testthat/test-CWB_FixedSchedule.R
@@ -1,375 +1,637 @@
 test_that("CWB_FixedSchedule() works as expected in example", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
-  tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz, Kc=Kc,
-             Irrig=Irrig, MAD=MAD, Scheduling=Scheduling,  start.date = "2023-11-23")
+  tes <-
+    CWB_FixedSchedule(
+      Rain = Rain,
+      ET0 = ET0,
+      AWC = AWC,
+      Drz = Drz,
+      Kc = Kc,
+      Irrig = Irrig,
+      MAD = MAD,
+      Scheduling = Scheduling,
+      start.date = "2023-11-23"
+    )
   expect_s3_class(tes, "data.frame")
   expect_length(tes, 14)
   expect_equal(nrow(tes), 129)
   expect_named(
     tes,
-    c("DaysSeason","Rain","Irrig","ET0","Kc","WaterStressCoef_Ks","ETc", "(P+Irrig)-ETc","NonStandardCropEvap",
-      "ET_Defict","TAW","SoilWaterDeficit","d_MAD", "Scheduling"))
-  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372,4.171917,4.290477),tolerance = 0.01)
-  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000,0.000000000,0.000000000),tolerance = 0.01)
-  expect_equal(tes[1:3, "TAW"], c(45.72,45.72,45.72),tolerance = 0.01)
-  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000,3.9179166,8.2083937),tolerance = 0.01)
-  expect_equal(tes[1:3, "d_MAD"], c(13.716,13.716,13.716),tolerance = 0.01)
-  expect_equal(tes[1:3, "Scheduling"], c("No","No","No"))
+    c(
+      "DaysSeason",
+      "Rain",
+      "Irrig",
+      "ET0",
+      "Kc",
+      "WaterStressCoef_Ks",
+      "ETc",
+      "(P+Irrig)-ETc",
+      "NonStandardCropEvap",
+      "ET_Defict",
+      "TAW",
+      "SoilWaterDeficit",
+      "d_MAD",
+      "Scheduling"
+    )
+  )
+  expect_equal(tes[1:3, "NonStandardCropEvap"],
+               c(2.440372, 4.171917, 4.290477), tolerance = 0.01)
+  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000, 0.000000000, 0.000000000),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "TAW"], c(45.72, 45.72, 45.72), tolerance = 0.01)
+  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000, 3.9179166, 8.2083937),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "d_MAD"], c(13.716, 13.716, 13.716), tolerance = 0.01)
+  expect_equal(tes[1:3, "Scheduling"], c("No", "No", "No"))
 })
 
-test_that("CWB_FixedSchedule() works as expected when initialD is provided", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
-  Scheduling <- 5
-  tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz, Kc=Kc,
-             Irrig=Irrig, MAD=MAD, Scheduling=Scheduling,  InitialD=0, start.date = "2023-11-23")
-  expect_s3_class(tes, "data.frame")
-  expect_length(tes, 14)
-  expect_equal(nrow(tes), 129)
-  expect_named(
-    tes,
-    c("DaysSeason","Rain","Irrig","ET0","Kc","WaterStressCoef_Ks","ETc", "(P+Irrig)-ETc","NonStandardCropEvap",
-      "ET_Defict","TAW","SoilWaterDeficit","d_MAD", "Scheduling"))
-  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372,4.171917,4.290477),tolerance = 0.01)
-  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000,0.000000000,0.000000000),tolerance = 0.01)
-  expect_equal(tes[1:3, "TAW"], c(45.72,45.72,45.72),tolerance = 0.01)
-  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000,3.9179166,8.2083937),tolerance = 0.01)
-  expect_equal(tes[1:3, "d_MAD"], c(13.716,13.716,13.716),tolerance = 0.01)
-  expect_equal(tes[1:3, "Scheduling"], c("No","No","No"))
-})
+test_that("CWB_FixedSchedule() works as expected when initialD is provided",
+          {
+            Tavg <- DataForCWB[, 2]
+            Tmax <- DataForCWB[, 3]
+            Tmin <- DataForCWB[, 4]
+            Rn <- DataForCWB[, 6]
+            WS <- DataForCWB[, 7]
+            RH <- DataForCWB[, 8]
+            G <- DataForCWB[, 9]
+            ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+            Rain <- DataForCWB[, 10]
+            Drz <- DataForCWB[, 11]
+            AWC <- DataForCWB[, 12]
+            MAD <- DataForCWB[, 13]
+            Kc <- DataForCWB[, 14]
+            Irrig <- DataForCWB[, 15]
+            Scheduling <- 5
+            tes <-
+              CWB_FixedSchedule(
+                Rain = Rain,
+                ET0 = ET0,
+                AWC = AWC,
+                Drz = Drz,
+                Kc = Kc,
+                Irrig = Irrig,
+                MAD = MAD,
+                Scheduling = Scheduling,
+                InitialD = 0,
+                start.date = "2023-11-23"
+              )
+            expect_s3_class(tes, "data.frame")
+            expect_length(tes, 14)
+            expect_equal(nrow(tes), 129)
+            expect_named(
+              tes,
+              c(
+                "DaysSeason",
+                "Rain",
+                "Irrig",
+                "ET0",
+                "Kc",
+                "WaterStressCoef_Ks",
+                "ETc",
+                "(P+Irrig)-ETc",
+                "NonStandardCropEvap",
+                "ET_Defict",
+                "TAW",
+                "SoilWaterDeficit",
+                "d_MAD",
+                "Scheduling"
+              )
+            )
+            expect_equal(tes[1:3, "NonStandardCropEvap"],
+                         c(2.440372, 4.171917, 4.290477), tolerance = 0.01)
+            expect_equal(tes[1:3, "ET_Defict"],
+                         c(0.000000000, 0.000000000, 0.000000000),
+                         tolerance = 0.01)
+            expect_equal(tes[1:3, "TAW"], c(45.72, 45.72, 45.72),
+                         tolerance = 0.01)
+            expect_equal(tes[1:3, "SoilWaterDeficit"],
+                         c(0.0000000, 3.9179166, 8.2083937), tolerance = 0.01)
+            expect_equal(tes[1:3, "d_MAD"],
+                         c(13.716, 13.716, 13.716), tolerance = 0.01)
+            expect_equal(tes[1:3, "Scheduling"], c("No", "No", "No"))
+          })
 
 test_that("Wrong date format", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   start.date <- "date"
   expect_error(
-    CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz, Kc=Kc,
-               Irrig=Irrig, MAD=MAD, Scheduling=Scheduling,  start.date = start.date),
+    CWB_FixedSchedule(
+      Rain = Rain,
+      ET0 = ET0,
+      AWC = AWC,
+      Drz = Drz,
+      Kc = Kc,
+      Irrig = Irrig,
+      MAD = MAD,
+      Scheduling = Scheduling,
+      start.date = start.date
+    ),
     "`date` is not in a valid date format. Please enter a valid date format."
   )
 })
 
 
 test_that("CWB_FixedSchedule() works as expected When Kc is NULL", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Irrig <- DataForCWB[,15]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
-  tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz,  Irri=Irrig,
-             MAD=MAD, Scheduling=Scheduling,  start.date = "2023-11-23")
+  tes <-
+    CWB_FixedSchedule(
+      Rain = Rain,
+      ET0 = ET0,
+      AWC = AWC,
+      Drz = Drz,
+      Irri = Irrig,
+      MAD = MAD,
+      Scheduling = Scheduling,
+      start.date = "2023-11-23"
+    )
   expect_s3_class(tes, "data.frame")
   expect_length(tes, 14)
   expect_equal(nrow(tes), 129)
   expect_named(
     tes,
-    c("DaysSeason","Rain","Irrig","ET0","Kc","WaterStressCoef_Ks","ETc", "(P+Irrig)-ETc","NonStandardCropEvap",
-      "ET_Defict","TAW","SoilWaterDeficit","d_MAD", "Scheduling"))
-  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372,4.171917,4.290477),tolerance = 0.01)
-  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000,0.000000000,0.000000000),tolerance = 0.01)
-  expect_equal(tes[1:3, "TAW"], c(45.72,45.72,45.72),tolerance = 0.01)
-  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000,3.9179166,8.2083937),tolerance = 0.01)
-  expect_equal(tes[1:3, "d_MAD"], c(13.716,13.716,13.716),tolerance = 0.01)
-  expect_equal(tes[1:3, "Scheduling"], c("No","No","No"))
+    c(
+      "DaysSeason",
+      "Rain",
+      "Irrig",
+      "ET0",
+      "Kc",
+      "WaterStressCoef_Ks",
+      "ETc",
+      "(P+Irrig)-ETc",
+      "NonStandardCropEvap",
+      "ET_Defict",
+      "TAW",
+      "SoilWaterDeficit",
+      "d_MAD",
+      "Scheduling"
+    )
+  )
+  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372, 4.171917, 4.290477),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000, 0.000000000, 0.000000000),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "TAW"], c(45.72, 45.72, 45.72), tolerance = 0.01)
+  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000, 3.9179166, 8.2083937),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "d_MAD"], c(13.716, 13.716, 13.716), tolerance = 0.01)
+  expect_equal(tes[1:3, "Scheduling"], c("No", "No", "No"))
 })
 
 test_that("CWB_FixedSchedule() works as expected When Irrig is NULL", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
   #Irrig <- DataForCWB[,15]
   Scheduling <- 5
-  tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz, Kc=Kc,
-             MAD=MAD, Scheduling=Scheduling,  start.date = "2023-11-23")
+  tes <-
+    CWB_FixedSchedule(
+      Rain = Rain,
+      ET0 = ET0,
+      AWC = AWC,
+      Drz = Drz,
+      Kc = Kc,
+      MAD = MAD,
+      Scheduling = Scheduling,
+      start.date = "2023-11-23"
+    )
   expect_s3_class(tes, "data.frame")
   expect_length(tes, 14)
   expect_equal(nrow(tes), 129)
   expect_named(
     tes,
-    c("DaysSeason","Rain","Irrig","ET0","Kc","WaterStressCoef_Ks","ETc", "(P+Irrig)-ETc","NonStandardCropEvap",
-      "ET_Defict","TAW","SoilWaterDeficit","d_MAD", "Scheduling"))
-  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372,4.171917,4.290477),tolerance = 0.01)
-  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000,0.000000000,0.000000000),tolerance = 0.01)
-  expect_equal(tes[1:3, "TAW"], c(45.72,45.72,45.72),tolerance = 0.01)
-  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000,3.9179166,8.2083937),tolerance = 0.01)
-  expect_equal(tes[1:3, "d_MAD"], c(13.716,13.716,13.716),tolerance = 0.01)
-  expect_equal(tes[1:3, "Scheduling"], c("No","No","No"))
+    c(
+      "DaysSeason",
+      "Rain",
+      "Irrig",
+      "ET0",
+      "Kc",
+      "WaterStressCoef_Ks",
+      "ETc",
+      "(P+Irrig)-ETc",
+      "NonStandardCropEvap",
+      "ET_Defict",
+      "TAW",
+      "SoilWaterDeficit",
+      "d_MAD",
+      "Scheduling"
+    )
+  )
+  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372, 4.171917, 4.290477),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000, 0.000000000, 0.000000000),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "TAW"], c(45.72, 45.72, 45.72), tolerance = 0.01)
+  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000, 3.9179166, 8.2083937),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "d_MAD"], c(13.716, 13.716, 13.716), tolerance = 0.01)
+  expect_equal(tes[1:3, "Scheduling"], c("No", "No", "No"))
 })
 
 test_that("CWB_FixedSchedule() works as expected When MAD is NULL", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
   #MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
-  tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz, Kc=Kc,
-             Irrig=Irrig, Scheduling=Scheduling, start.date = "2023-11-23")
+  tes <-
+    CWB_FixedSchedule(
+      Rain = Rain,
+      ET0 = ET0,
+      AWC = AWC,
+      Drz = Drz,
+      Kc = Kc,
+      Irrig = Irrig,
+      Scheduling = Scheduling,
+      start.date = "2023-11-23"
+    )
   expect_s3_class(tes, "data.frame")
   expect_length(tes, 14)
   expect_equal(nrow(tes), 129)
   expect_named(
     tes,
-    c("DaysSeason","Rain","Irrig","ET0","Kc","WaterStressCoef_Ks","ETc", "(P+Irrig)-ETc","NonStandardCropEvap",
-      "ET_Defict","TAW","SoilWaterDeficit","d_MAD", "Scheduling"))
-  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372,4.171917,4.290477),tolerance = 0.01)
-  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000,0.000000000,0.000000000),tolerance = 0.01)
-  expect_equal(tes[1:3, "TAW"], c(45.72,45.72,45.72),tolerance = 0.01)
-  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000,3.9179166,8.2083937),tolerance = 0.01)
-  expect_equal(tes[1:3, "d_MAD"], c(13.716,13.716,13.716),tolerance = 0.01)
-  expect_equal(tes[1:3, "Scheduling"], c("No","No","No"))
+    c(
+      "DaysSeason",
+      "Rain",
+      "Irrig",
+      "ET0",
+      "Kc",
+      "WaterStressCoef_Ks",
+      "ETc",
+      "(P+Irrig)-ETc",
+      "NonStandardCropEvap",
+      "ET_Defict",
+      "TAW",
+      "SoilWaterDeficit",
+      "d_MAD",
+      "Scheduling"
+    )
+  )
+  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372, 4.171917, 4.290477),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000, 0.000000000, 0.000000000),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "TAW"], c(45.72, 45.72, 45.72), tolerance = 0.01)
+  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000, 3.9179166, 8.2083937),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "d_MAD"], c(13.716, 13.716, 13.716), tolerance = 0.01)
+  expect_equal(tes[1:3, "Scheduling"], c("No", "No", "No"))
 })
 
 test_that("CWB_FixedSchedule() works as expected when G is NULL", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  expect_warning(
-    ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,Alt=700),
-    "The first 3 G values were set to zero")
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  expect_warning(ET0 <-
+                   ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, Alt = 700),
+                 "The first 3 G values were set to zero")
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
-  tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz,  MAD=MAD, Scheduling=Scheduling,
-             Kc=Kc, Irrig=Irrig, start.date = "2023-11-23")
+  tes <-
+    CWB_FixedSchedule(
+      Rain = Rain,
+      ET0 = ET0,
+      AWC = AWC,
+      Drz = Drz,
+      MAD = MAD,
+      Scheduling = Scheduling,
+      Kc = Kc,
+      Irrig = Irrig,
+      start.date = "2023-11-23"
+    )
   expect_s3_class(tes, "data.frame")
   expect_length(tes, 14)
   expect_equal(nrow(tes), 129)
   expect_named(
     tes,
-    c("DaysSeason","Rain","Irrig","ET0","Kc","WaterStressCoef_Ks","ETc", "(P+Irrig)-ETc","NonStandardCropEvap",
-      "ET_Defict","TAW","SoilWaterDeficit","d_MAD", "Scheduling"))
-  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.293183,4.104242,4.333359),tolerance = 0.01)
-  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000,0.000000000,0.000000000),tolerance = 0.01)
-  expect_equal(tes[1:3, "TAW"], c(45.72,45.72,45.72),tolerance = 0.01)
-  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000,3.8502425,8.1836018),tolerance = 0.01)
-  expect_equal(tes[1:3, "d_MAD"], c(13.716,13.716,13.716),tolerance = 0.01)
-  expect_equal(tes[1:3, "Scheduling"], c("No","No","No"))
+    c(
+      "DaysSeason",
+      "Rain",
+      "Irrig",
+      "ET0",
+      "Kc",
+      "WaterStressCoef_Ks",
+      "ETc",
+      "(P+Irrig)-ETc",
+      "NonStandardCropEvap",
+      "ET_Defict",
+      "TAW",
+      "SoilWaterDeficit",
+      "d_MAD",
+      "Scheduling"
+    )
+  )
+  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.293183, 4.104242, 4.333359),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000, 0.000000000, 0.000000000),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "TAW"], c(45.72, 45.72, 45.72), tolerance = 0.01)
+  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000, 3.8502425, 8.1836018),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "d_MAD"], c(13.716, 13.716, 13.716), tolerance = 0.01)
+  expect_equal(tes[1:3, "Scheduling"], c("No", "No", "No"))
 })
 
-test_that("CWB_FixedSchedule() works as expected when P<ET0 on the very first day", {
-  data(DataForCWB)
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  ET0 <- ET0[2:10]
-  ET0 <- as.matrix(ET0)
-  Rain <- DataForCWB[2:10,10]
-  Drz <- DataForCWB[2:10,11]
-  AWC <- DataForCWB[2:10,12]
-  MAD <- DataForCWB[2:10,13]
-  Kc <- DataForCWB[2:10,14]
-  Ks <- DataForCWB[2:10,15]
-  Irrig <- DataForCWB[2:10,16]
-  Scheduling <- 5
-  tes1 <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz,
-              Kc=Kc,  Irrig=Irrig, MAD=MAD, Scheduling=Scheduling,  start.date = "2023-11-23")
-  expect_s3_class(tes1, "data.frame")
-  expect_length(tes1, 14)
-  expect_equal(nrow(tes1), 9)
-  expect_named(
-    tes1,
-    c("DaysSeason","Rain","Irrig","ET0","Kc","WaterStressCoef_Ks","ETc", "(P+Irrig)-ETc","NonStandardCropEvap",
-      "ET_Defict","TAW","SoilWaterDeficit","d_MAD", "Scheduling"))
-  expect_equal(tes1[1:3, "NonStandardCropEvap"], c(4.171917,4.290477,3.665459),tolerance = 0.01)
-  expect_equal(tes1[1:3, "ET_Defict"], c(0.0000000,0.0000000,0.0000000),tolerance = 0.01)
-  expect_equal(tes1[1:3, "TAW"], c(45.72,45.72,45.72),tolerance = 0.01)
-  expect_equal(tes1[1:3, "SoilWaterDeficit"], c(3.9179166,8.2083937,0.4438527),tolerance = 0.01)
-  expect_equal(tes1[1:3, "d_MAD"], c(13.716,13.716,13.716),tolerance = 0.01)
-  expect_equal(tes1[1:3, "Scheduling"], c("No","No","No"))
-})
+test_that("CWB_FixedSchedule() works as expected when P<ET0 on first day",
+          {
+            Tavg <- DataForCWB[, 2]
+            Tmax <- DataForCWB[, 3]
+            Tmin <- DataForCWB[, 4]
+            Rn <- DataForCWB[, 6]
+            WS <- DataForCWB[, 7]
+            RH <- DataForCWB[, 8]
+            G <- DataForCWB[, 9]
+            ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+            ET0 <- ET0[2:10]
+            ET0 <- as.matrix(ET0)
+            Rain <- DataForCWB[2:10, 10]
+            Drz <- DataForCWB[2:10, 11]
+            AWC <- DataForCWB[2:10, 12]
+            MAD <- DataForCWB[2:10, 13]
+            Kc <- DataForCWB[2:10, 14]
+            Ks <- DataForCWB[2:10, 15]
+            Irrig <- DataForCWB[2:10, 16]
+            Scheduling <- 5
+            tes1 <- CWB_FixedSchedule(
+              Rain = Rain,
+              ET0 = ET0,
+              AWC = AWC,
+              Drz = Drz,
+              Kc = Kc,
+              Irrig = Irrig,
+              MAD = MAD,
+              Scheduling = Scheduling,
+              start.date = "2023-11-23"
+            )
+            expect_s3_class(tes1, "data.frame")
+            expect_length(tes1, 14)
+            expect_equal(nrow(tes1), 9)
+            expect_named(
+              tes1,
+              c(
+                "DaysSeason",
+                "Rain",
+                "Irrig",
+                "ET0",
+                "Kc",
+                "WaterStressCoef_Ks",
+                "ETc",
+                "(P+Irrig)-ETc",
+                "NonStandardCropEvap",
+                "ET_Defict",
+                "TAW",
+                "SoilWaterDeficit",
+                "d_MAD",
+                "Scheduling"
+              )
+            )
+            expect_equal(tes1[1:3, "NonStandardCropEvap"],
+                         c(4.171917, 4.290477, 3.665459), tolerance = 0.01)
+            expect_equal(tes1[1:3, "ET_Defict"],
+                         c(0.0000000, 0.0000000, 0.0000000), tolerance = 0.01)
+            expect_equal(tes1[1:3, "TAW"],
+                         c(45.72, 45.72, 45.72), tolerance = 0.01)
+            expect_equal(tes1[1:3, "SoilWaterDeficit"],
+                         c(3.9179166, 8.2083937, 0.4438527), tolerance = 0.01)
+            expect_equal(tes1[1:3, "d_MAD"],
+                         c(13.716, 13.716, 13.716), tolerance = 0.01)
+            expect_equal(tes1[1:3, "Scheduling"], c("No", "No", "No"))
+          })
 
 test_that("Physically impossible rain values", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- (-1*DataForCWB[,10])
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- (-1 * DataForCWB[, 10])
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   expect_error(
-    tes <- CWB_FixedSchedule(Rain, ET0, AWC, Drz,  Kc, Ks, Irrig, Scheduling=Scheduling, start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain,
+        ET0,
+        AWC,
+        Drz,
+        Kc,
+        Ks,
+        Irrig,
+        Scheduling = Scheduling,
+        start.date = "2023-11-23"
+      ),
     "Physically impossible or missing rain values"
   )
 })
 
 test_that("Missing rain values", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
   Rain[1] <- NA
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   expect_error(
-    tes <- CWB_FixedSchedule(Rain, ET0, AWC, Drz,  Kc, Ks, Irrig, Scheduling=Scheduling, start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain,
+        ET0,
+        AWC,
+        Drz,
+        Kc,
+        Ks,
+        Irrig,
+        Scheduling = Scheduling,
+        start.date = "2023-11-23"
+      ),
     "Physically impossible or missing rain values"
   )
 })
 
 test_that("Wrong format rain", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- cbind(DataForCWB[,10],DataForCWB[,10])
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- cbind(DataForCWB[, 10], DataForCWB[, 10])
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   expect_error(
-    tes <- CWB_FixedSchedule(Rain, ET0, AWC, Drz, Kc, Ks, Irrig, MAD, Scheduling=Scheduling, start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain,
+        ET0,
+        AWC,
+        Drz,
+        Kc,
+        Ks,
+        Irrig,
+        MAD,
+        Scheduling = Scheduling,
+        start.date = "2023-11-23"
+      ),
     "Physically impossible or missing rain values"
   )
 })
 
 test_that("Physically impossible Kc values", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   Kc[1] <- 40
   expect_error(
-    tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz, MAD=MAD, Scheduling=Scheduling,  Kc=Kc,
-               Irrig=Irrig, start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain = Rain,
+        ET0 = ET0,
+        AWC = AWC,
+        Drz = Drz,
+        MAD = MAD,
+        Scheduling = Scheduling,
+        Kc = Kc,
+        Irrig = Irrig,
+        start.date = "2023-11-23"
+      ),
     "Inputs must be numerical variables with no missing value.
         Also check if the input are physically sound."
   )
 })
 
 test_that("Missing Kc values", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   Kc[1] <- NA
   expect_error(
-    tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz, MAD=MAD, Scheduling=Scheduling,  Kc=Kc,
-               Irrig=Irrig, start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain = Rain,
+        ET0 = ET0,
+        AWC = AWC,
+        Drz = Drz,
+        MAD = MAD,
+        Scheduling = Scheduling,
+        Kc = Kc,
+        Irrig = Irrig,
+        start.date = "2023-11-23"
+      ),
     "Inputs must be numerical variables with no missing value.
         Also check if the input are physically sound."
   )
@@ -377,224 +639,314 @@ test_that("Missing Kc values", {
 
 
 test_that("Negative Irrig values", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- rep(-0.8,129)
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- rep(-0.8, 129)
   Scheduling <- 5
   expect_error(
-    tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz, MAD=MAD, Scheduling=Scheduling,  Kc=Kc,
-               Irrig=Irrig, start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain = Rain,
+        ET0 = ET0,
+        AWC = AWC,
+        Drz = Drz,
+        MAD = MAD,
+        Scheduling = Scheduling,
+        Kc = Kc,
+        Irrig = Irrig,
+        start.date = "2023-11-23"
+      ),
     "Inputs must be numerical variables with no missing value.
         Also check if the input are physically sound."
   )
 })
 
 test_that("Missing Irrig values", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   Irrig[1] <- NA
   expect_error(
-    tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz, MAD=MAD, Scheduling=Scheduling,  Kc=Kc,
-               Irrig=Irrig, start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain = Rain,
+        ET0 = ET0,
+        AWC = AWC,
+        Drz = Drz,
+        MAD = MAD,
+        Scheduling = Scheduling,
+        Kc = Kc,
+        Irrig = Irrig,
+        start.date = "2023-11-23"
+      ),
     "Inputs must be numerical variables with no missing value.
         Also check if the input are physically sound."
   )
 })
 
 test_that("Physically impossible MAD values", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   MAD[1:4] <- 4
   expect_error(
-    tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz, MAD=MAD, Scheduling=Scheduling,  Kc=Kc,
-               Irrig=Irrig, start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain = Rain,
+        ET0 = ET0,
+        AWC = AWC,
+        Drz = Drz,
+        MAD = MAD,
+        Scheduling = Scheduling,
+        Kc = Kc,
+        Irrig = Irrig,
+        start.date = "2023-11-23"
+      ),
     "Inputs must be numerical variables with no missing value.
         Also check if the input are physically sound."
   )
 })
 
 test_that("Wrong MAD values. Single number", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
   MAD <- 4
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   expect_error(
-    tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz, MAD=MAD, Scheduling=Scheduling,  Kc=Kc,
-               Irrig=Irrig, start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain = Rain,
+        ET0 = ET0,
+        AWC = AWC,
+        Drz = Drz,
+        MAD = MAD,
+        Scheduling = Scheduling,
+        Kc = Kc,
+        Irrig = Irrig,
+        start.date = "2023-11-23"
+      ),
     "Inputs must be numerical variables with no missing value.
         Also check if the input are physically sound."
   )
 })
 
 test_that("Physically impossible Drz values", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
   Drz[1] <- (-4)
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   expect_error(
-    tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz, MAD=MAD, Scheduling=Scheduling,  Kc=Kc,
-               Irrig=Irrig, start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain = Rain,
+        ET0 = ET0,
+        AWC = AWC,
+        Drz = Drz,
+        MAD = MAD,
+        Scheduling = Scheduling,
+        Kc = Kc,
+        Irrig = Irrig,
+        start.date = "2023-11-23"
+      ),
     "Inputs must be numerical variables with no missing value.
         Also check if the input are physically sound."
   )
 })
 
 test_that("Wrong Drz values. Character", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
   Drz[1] <- "profunda"
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   expect_error(
-    tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz, MAD=MAD, Scheduling=Scheduling,  Kc=Kc,
-               Irrig=Irrig, start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain = Rain,
+        ET0 = ET0,
+        AWC = AWC,
+        Drz = Drz,
+        MAD = MAD,
+        Scheduling = Scheduling,
+        Kc = Kc,
+        Irrig = Irrig,
+        start.date = "2023-11-23"
+      ),
     "Inputs must be numerical variables with no missing value.
         Also check if the input are physically sound."
   )
 })
 
 test_that("Physically impossible AWC values", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
   AWC[1] <- 0
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   expect_error(
-    tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz, MAD=MAD, Scheduling=Scheduling,  Kc=Kc,
-               Irrig=Irrig, start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain = Rain,
+        ET0 = ET0,
+        AWC = AWC,
+        Drz = Drz,
+        MAD = MAD,
+        Scheduling = Scheduling,
+        Kc = Kc,
+        Irrig = Irrig,
+        start.date = "2023-11-23"
+      ),
     "Inputs must be numerical variables with no missing value.
         Also check if the input are physically sound."
   )
 })
 
 test_that("Wrong AWC values. Single number", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
   AWC <- 0.4
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   expect_error(
-    tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz, MAD=MAD, Scheduling=Scheduling,  Kc=Kc,
-               Irrig=Irrig, start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain = Rain,
+        ET0 = ET0,
+        AWC = AWC,
+        Drz = Drz,
+        MAD = MAD,
+        Scheduling = Scheduling,
+        Kc = Kc,
+        Irrig = Irrig,
+        start.date = "2023-11-23"
+      ),
     "Inputs must be numerical variables with no missing value.
         Also check if the input are physically sound."
   )
 })
 
 test_that("Rain and ET0 different lengths", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
   ET0 <- ET0[1:20]
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
   AWC <- 0.4
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   expect_error(
-    tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz, MAD=MAD, Scheduling=Scheduling,  Kc=Kc,
-               Irrig=Irrig, start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain = Rain,
+        ET0 = ET0,
+        AWC = AWC,
+        Drz = Drz,
+        MAD = MAD,
+        Scheduling = Scheduling,
+        Kc = Kc,
+        Irrig = Irrig,
+        start.date = "2023-11-23"
+      ),
     "Inputs must be numerical variables with no missing value.
         Also check if the input are physically sound."
   )
@@ -602,217 +954,334 @@ test_that("Rain and ET0 different lengths", {
 
 
 test_that("Wrong InitialD larger than TAW", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   expect_error(
-    tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz,  MAD=MAD, Scheduling=Scheduling,
-               Kc=Kc, Irrig=Irrig, InitialD=80, start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain = Rain,
+        ET0 = ET0,
+        AWC = AWC,
+        Drz = Drz,
+        MAD = MAD,
+        Scheduling = Scheduling,
+        Kc = Kc,
+        Irrig = Irrig,
+        InitialD = 80,
+        start.date = "2023-11-23"
+      ),
     "InitialD must be a single positive number no larger than TAW"
   )
 })
 
 test_that("Wrong InitialD negative value", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   expect_error(
-    tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz,  MAD=MAD, Scheduling=Scheduling,
-               Kc=Kc, Irrig=Irrig, InitialD=-80, start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain = Rain,
+        ET0 = ET0,
+        AWC = AWC,
+        Drz = Drz,
+        MAD = MAD,
+        Scheduling = Scheduling,
+        Kc = Kc,
+        Irrig = Irrig,
+        InitialD = -80,
+        start.date = "2023-11-23"
+      ),
     "InitialD must be a single positive number no larger than TAW"
   )
 })
 
 test_that("Wrong InitialD length", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   expect_error(
-    tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz,  MAD=MAD, Scheduling=Scheduling,
-               Kc=Kc, Irrig=Irrig, InitialD=c(80,40), start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain = Rain,
+        ET0 = ET0,
+        AWC = AWC,
+        Drz = Drz,
+        MAD = MAD,
+        Scheduling = Scheduling,
+        Kc = Kc,
+        Irrig = Irrig,
+        InitialD = c(80, 40),
+        start.date = "2023-11-23"
+      ),
     "InitialD must be a single positive number no larger than TAW"
   )
 })
 
 test_that("Wrong InitialD character", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   expect_error(
-    tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz,  MAD=MAD, Scheduling=Scheduling,
-               Kc=Kc, Irrig=Irrig, InitialD=c("Berger"), start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain = Rain,
+        ET0 = ET0,
+        AWC = AWC,
+        Drz = Drz,
+        MAD = MAD,
+        Scheduling = Scheduling,
+        Kc = Kc,
+        Irrig = Irrig,
+        InitialD = c("Berger"),
+        start.date = "2023-11-23"
+      ),
     "InitialD must be a single positive number no larger than TAW"
   )
 })
 
 test_that("Wrong start.date", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 5
   expect_error(
-    CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz,  MAD=MAD, Scheduling=Scheduling,
-               Kc=Kc, Irrig=Irrig, start.date = "string"),
+    CWB_FixedSchedule(
+      Rain = Rain,
+      ET0 = ET0,
+      AWC = AWC,
+      Drz = Drz,
+      MAD = MAD,
+      Scheduling = Scheduling,
+      Kc = Kc,
+      Irrig = Irrig,
+      start.date = "string"
+    ),
     "`string` is not in a valid date format. Please enter a valid date format."
   )
 })
 
 test_that("Wrong Scheduling Character", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- cbind(DataForCWB[,10],DataForCWB[,10])
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- cbind(DataForCWB[, 10], DataForCWB[, 10])
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- "five"
   expect_error(
-    tes <- CWB_FixedSchedule(Rain, ET0, AWC, Drz, Kc, Ks, Irrig, MAD, Scheduling=Scheduling, start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain,
+        ET0,
+        AWC,
+        Drz,
+        Kc,
+        Ks,
+        Irrig,
+        MAD,
+        Scheduling = Scheduling,
+        start.date = "2023-11-23"
+      ),
     "Scheduling must be a single positive number"
   )
 })
 
 test_that("Wrong Scheduling Character", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- cbind(DataForCWB[,10],DataForCWB[,10])
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
-  Scheduling <- c(5,5)
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- cbind(DataForCWB[, 10], DataForCWB[, 10])
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
+  Scheduling <- c(5, 5)
   expect_error(
-    tes <- CWB_FixedSchedule(Rain, ET0, AWC, Drz, Kc, Ks, Irrig, MAD, Scheduling=Scheduling, start.date = "2023-11-23"),
+    tes <-
+      CWB_FixedSchedule(
+        Rain,
+        ET0,
+        AWC,
+        Drz,
+        Kc,
+        Ks,
+        Irrig,
+        MAD,
+        Scheduling = Scheduling,
+        start.date = "2023-11-23"
+      ),
     "Scheduling must be a single positive number"
   )
 })
 
 test_that("Wrong Scheduling Character", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- cbind(DataForCWB[,10],DataForCWB[,10])
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- cbind(DataForCWB[, 10], DataForCWB[, 10])
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 0
   expect_error(
-    tes <- CWB_FixedSchedule(Rain, ET0, AWC, Drz, Kc, Ks, Irrig, MAD, Scheduling=Scheduling, start.date = "2023-11-23"),
+    CWB_FixedSchedule(
+      Rain,
+      ET0,
+      AWC,
+      Drz,
+      Kc,
+      Ks,
+      Irrig,
+      MAD,
+      Scheduling = Scheduling,
+      start.date = "2023-11-23"
+    ),
     "Scheduling must be a single positive number"
   )
 })
 
 test_that("CWB_FixedSchedule() works when Scheduling . 20", {
-  Tavg <- DataForCWB[,2]
-  Tmax <- DataForCWB[,3]
-  Tmin <- DataForCWB[,4]
-  Rn <- DataForCWB[,6]
-  WS <- DataForCWB[,7]
-  RH <- DataForCWB[,8]
-  G <- DataForCWB[,9]
-  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS,G,Alt=700)
-  Rain <- DataForCWB[,10]
-  Drz <- DataForCWB[,11]
-  AWC <- DataForCWB[,12]
-  MAD <- DataForCWB[,13]
-  Kc <- DataForCWB[,14]
-  Irrig <- DataForCWB[,15]
+  Tavg <- DataForCWB[, 2]
+  Tmax <- DataForCWB[, 3]
+  Tmin <- DataForCWB[, 4]
+  Rn <- DataForCWB[, 6]
+  WS <- DataForCWB[, 7]
+  RH <- DataForCWB[, 8]
+  G <- DataForCWB[, 9]
+  ET0 <- ET0_PM(Tavg, Tmax, Tmin, Rn, RH, WS, G, Alt = 700)
+  Rain <- DataForCWB[, 10]
+  Drz <- DataForCWB[, 11]
+  AWC <- DataForCWB[, 12]
+  MAD <- DataForCWB[, 13]
+  Kc <- DataForCWB[, 14]
+  Irrig <- DataForCWB[, 15]
   Scheduling <- 21
   expect_message(
-  tes <- CWB_FixedSchedule(Rain=Rain, ET0=ET0, AWC=AWC, Drz=Drz, Kc=Kc,
-                           Irrig=Irrig, MAD=MAD, Scheduling=Scheduling,  start.date = "2023-11-23"),
-  "Period between irrigations is longer than 20 days. Sure about it?")
+    tes <-
+      CWB_FixedSchedule(
+        Rain = Rain,
+        ET0 = ET0,
+        AWC = AWC,
+        Drz = Drz,
+        Kc = Kc,
+        Irrig = Irrig,
+        MAD = MAD,
+        Scheduling = Scheduling,
+        start.date = "2023-11-23"
+      ),
+    "Period between irrigations is longer than 20 days. Sure about it?"
+  )
   expect_s3_class(tes, "data.frame")
   expect_length(tes, 14)
   expect_equal(nrow(tes), 129)
   expect_named(
     tes,
-    c("DaysSeason","Rain","Irrig","ET0","Kc","WaterStressCoef_Ks","ETc", "(P+Irrig)-ETc","NonStandardCropEvap",
-      "ET_Defict","TAW","SoilWaterDeficit","d_MAD", "Scheduling"))
-  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372,4.171917,4.290477),tolerance = 0.01)
-  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000,0.000000000,0.000000000),tolerance = 0.01)
-  expect_equal(tes[1:3, "TAW"], c(45.72,45.72,45.72),tolerance = 0.01)
-  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000,3.9179166,8.2083937),tolerance = 0.01)
-  expect_equal(tes[1:3, "d_MAD"], c(13.716,13.716,13.716),tolerance = 0.01)
-  expect_equal(tes[1:3, "Scheduling"], c("No","No","No"))
+    c(
+      "DaysSeason",
+      "Rain",
+      "Irrig",
+      "ET0",
+      "Kc",
+      "WaterStressCoef_Ks",
+      "ETc",
+      "(P+Irrig)-ETc",
+      "NonStandardCropEvap",
+      "ET_Defict",
+      "TAW",
+      "SoilWaterDeficit",
+      "d_MAD",
+      "Scheduling"
+    )
+  )
+  expect_equal(tes[1:3, "NonStandardCropEvap"], c(2.440372, 4.171917, 4.290477),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "ET_Defict"], c(0.000000000, 0.000000000, 0.000000000),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "TAW"], c(45.72, 45.72, 45.72), tolerance = 0.01)
+  expect_equal(tes[1:3, "SoilWaterDeficit"], c(0.0000000, 3.9179166, 8.2083937),
+               tolerance = 0.01)
+  expect_equal(tes[1:3, "d_MAD"], c(13.716, 13.716, 13.716), tolerance = 0.01)
+  expect_equal(tes[1:3, "Scheduling"], c("No", "No", "No"))
 })


### PR DESCRIPTION
## Major changes

* Converts README.md to README.Rmd and knitting it.
This ensures that all the examples work, _e.g._, `ET0_PM()` was lacking `ALT` and would not run.
* Adds NEWS.md file

## Minor changes
* Lints the long lines
* Removes redundant calls for `Data(DataForCWB)`. The data are lazy loaded, there is no need to call them again during the user session. You would only need to do this and specify the package as well if you wanted to use the data when you don't have {CropWaterBalance} loaded in your R session.
